### PR TITLE
[Feat]: P2 cold miss recovery and plotting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ configs/live_e2e/*.yaml
 .codex
 
 results/
+autoresearch-results.tsv

--- a/CoLoRA-reference.bib
+++ b/CoLoRA-reference.bib
@@ -20,36 +20,13 @@
   year={2021}
 }
 
-123
-@article{todo:moe-llm,
-  title={Mixtral of experts},
-  author={Jiang, Albert Q and Sablayrolles, Alexandre and Roux, Antoine and Mensch, Arthur and Savary, Blanche and Bamford, Chris and Chaplot, Devendra Singh and Casas, Diego de las and Hanna, Emma Bou and Bressand, Florian and others},
-  journal={arXiv preprint arXiv:2401.04088},
-  year={2024}
-}
-
-@inproceedings{todo:lora-original,
-  title={{LoRA}: Low-Rank Adaptation of Large Language Models},
-  author={Edward J Hu and Yelong Shen and Phillip Wallis and Zeyuan Allen-Zhu and Yuanzhi Li and Shean Wang and Lu Wang and Weizhu Chen},
-  booktitle={International Conference on Learning Representations (ICLR)},
-  year={2022}
-}
-
-@inproceedings{todo:lora-attention-focus,
-  title={{QLoRA}: Efficient Finetuning of Quantized {LLMs}},
+@article{dettmers2023qlora,
+  title={Qlora: Efficient finetuning of quantized llms},
   author={Dettmers, Tim and Pagnoni, Artidoro and Holtzman, Ari and Zettlemoyer, Luke},
-  booktitle={Advances in Neural Information Processing Systems (NeurIPS)},
+  journal={Advances in neural information processing systems},
+  volume={36},
+  pages={10088--10115},
   year={2023}
-}
-
-@article{todo:moe-knowledge-capacity,
-  title={Switch Transformers: Scaling to Trillion Parameter Models with Simple and Efficient Sparsity},
-  author={Fedus, William and Zoph, Barret and Shazeer, Noam},
-  journal={Journal of Machine Learning Research (JMLR)},
-  volume={23},
-  number={120},
-  pages={1--39},
-  year={2022}
 }
 
 @article{schulman2025lora,
@@ -61,18 +38,13 @@
   doi = {10.64434/tml.20250929},
 }
 
-@inproceedings{todo:moe-routing-dynamics,
-  title={{MegaBlocks}: Efficient Sparse Training with Mixture-of-Experts},
+@article{gale2023megablocks,
+  title={Megablocks: Efficient sparse training with mixture-of-experts},
   author={Gale, Trevor and Narayanan, Deepak and Young, Cliff and Zaharia, Matei},
-  booktitle={Proceedings of Machine Learning and Systems (MLSys)},
+  journal={Proceedings of Machine Learning and Systems},
+  volume={5},
+  pages={288--304},
   year={2023}
-}
-
-@inproceedings{todo:pd-serving,
-  title={Splitwise: Efficient generative {LLM} inference using phase splitting},
-  author={Patel, Pratyush and Choukse, Esha and Zhang, Chaojie interventions and Shah, Aashaka and Goiri, {\'I}{\~n}igo and Maleki, Saeed and Bianchini, Ricardo},
-  booktitle={ACM/IEEE 51st Annual International Symposium on Computer Architecture (ISCA)},
-  year={2024}
 }
 
 @article{sheng2024slora,
@@ -90,13 +62,6 @@
   booktitle={Proceedings of the Twentieth European Conference on Computer Systems},
   pages={261--277},
   year={2025}
-}
-
-@inproceedings{todo:moe-ffn-architecture,
-  title={Outrageously Large Neural Networks: The Sparsely-Gated Mixture-of-Experts Layer},
-  author={Shazeer, Noam and Mirhoseini, Azalia and Maziarz, Krzysztof and Davis, Andy and Le, Quoc and Hinton, Geoffrey and Dean, Jeff},
-  booktitle={International Conference on Learning Representations (ICLR)},
-  year={2017}
 }
 
 @article{zhu2024deepseek,
@@ -266,5 +231,13 @@
   author={Na, Seonjin and Jeong, Geonhwa and Ahn, Byung H and Jezghani, Aaron and Young, Jeffrey and Hughes, Christopher J and Krishna, Tushar and Kim, Hyesoon},
   journal={Proceedings of Machine Learning and Systems},
   volume={7},
+  year={2025}
+}
+
+@inproceedings{iliakopoulou2025chameleon,
+  title={Chameleon: Adaptive caching and scheduling for many-adapter llm inference environments},
+  author={Iliakopoulou, Nikoleta and Stojkovic, Jovan and Alverti, Chloe and Xu, Tianyin and Franke, Hubertus and Torrellas, Josep},
+  booktitle={Proceedings of the 58th IEEE/ACM International Symposium on Microarchitecture},
+  pages={217--231},
   year={2025}
 }

--- a/CoLoRA.tex
+++ b/CoLoRA.tex
@@ -143,12 +143,12 @@ We present CoLoRA, a serving runtime that treats GPU memory misses as an executi
 \section{Introduction}
 \label{sec:introduction}
 
-Large-scale LLM serving is increasingly shaped by the convergence of two trends: sparse Mixture-of-Experts (MoE) base models~\cite{jiang2024mixtral} and LoRA-based multi-tenant adaptation~\cite{hu2022lora,sheng2024slora}. In practice, these trends meet in \emph{multi-LoRA MoE serving}. While existing multi-LoRA systems target dense modules such as attention layers and shared FFNs, they do not directly address adaptation on sparsely activated MoE expert layers~\cite{chen2024punica,sheng2024slora}. This gap is critical: MoE expert FFN blocks comprise the majority of model capacity, making them the natural target for tenant-specific specialization~\cite{sfedus2022switch,schulman2025lora}. This combination couples the compute efficiency of MoE with the parameter efficiency of LoRA. However, it creates a new serving regime in which request-time sparse routing and tenant-specific adapter selection jointly shape the active weights. This significantly enlarges and diversifies the inference working set, rendering it difficult to manage with existing caching strategies.
-% v2: Large-scale LLM serving is increasingly shaped by the convergence of two trends that are individually effective but jointly nontrivial to serve: sparse Mixture-of-Experts (MoE) base models~\cite{jiang2024mixtral} and LoRA-based multi-tenant adaptation~\cite{hu2022lora,sheng2024slora}. In practice, these trends naturally meet in \emph{multi-LoRA MoE serving}. Existing multi-LoRA serving systems, however, are primarily designed for dense backbones and do not directly address adaptation on sparsely activated MoE expert layers~\cite{chen2024punica,sheng2024slora}. Such adaptation is both natural and important: MoE expert FFN blocks comprise a large fraction of model capacity and are a natural target for tenant-specific specialization~\cite{sfedus2022switch, schulman2025lora}. The resulting combination is attractive because it couples the compute efficiency of MoE with the parameter efficiency of LoRA. At the same time, it creates a new serving regime in which request-time sparse routing and tenant-specific adapter selection jointly shape the active weight set, making the inference working set larger, more diverse, and harder to manage efficiently.
+Large-scale LLM serving is increasingly shaped by the convergence of two trends: sparse Mixture-of-Experts (MoE) base models~\cite{jiang2024mixtral} and LoRA-based multi-tenant adaptation~\cite{hu2022lora,sheng2024slora}. In practice, these trends meet in \emph{multi-LoRA MoE serving}. While existing multi-LoRA systems target dense modules such as attention layers and shared FFNs, they do not directly address adaptation on sparsely activated MoE expert layers~\cite{chen2024punica,sheng2024slora}. This gap is critical: MoE expert FFN blocks comprise the majority of model capacity, making them the natural target for tenant-specific specialization~\cite{fedus2022switch,schulman2025lora}. This combination couples the compute efficiency of MoE with the parameter efficiency of LoRA. However, it creates a new serving regime in which request-time sparse routing and tenant-specific adapter selection jointly shape the active weights. This significantly enlarges and diversifies the inference working set, rendering it difficult to manage with existing caching strategies.
+% v2: Large-scale LLM serving is increasingly shaped by the convergence of two trends that are individually effective but jointly nontrivial to serve: sparse Mixture-of-Experts (MoE) base models~\cite{jiang2024mixtral} and LoRA-based multi-tenant adaptation~\cite{hu2022lora,sheng2024slora}. In practice, these trends naturally meet in \emph{multi-LoRA MoE serving}. Existing multi-LoRA serving systems, however, are primarily designed for dense backbones and do not directly address adaptation on sparsely activated MoE expert layers~\cite{chen2024punica,sheng2024slora}. Such adaptation is both natural and important: MoE expert FFN blocks comprise a large fraction of model capacity and are a natural target for tenant-specific specialization~\cite{fedus2022switch, schulman2025lora}. The resulting combination is attractive because it couples the compute efficiency of MoE with the parameter efficiency of LoRA. At the same time, it creates a new serving regime in which request-time sparse routing and tenant-specific adapter selection jointly shape the active weight set, making the inference working set larger, more diverse, and harder to manage efficiently.
 %
 %Note: In this version, \cite{gale2023megablocks} to be moved to Related Work if not cited elsewhere.
 %
-% v1: Large-scale LLM serving is increasingly shaped by the convergence of two trends that are each effective in isolation but jointly challenging in deployment: sparse Mixture-of-Experts (MoE) base models~\cite{jiang2024mixtral} and LoRA-based multi-tenant adaptation~\cite{hu2022lora,sheng2024slora}. In production settings, these trends naturally meet in \emph{multi-LoRA MoE serving}. While LoRA is widely used as a lightweight mechanism for tenant-specific customization, existing multi-LoRA serving systems have largely been designed for dense-model adaptation rather than expert-layer adaptation in sparse MoE models~\cite{chen2024punica,sheng2024slora}. Extending LoRA to MoE expert layers is both natural and practically important, because expert FFN blocks account for a large fraction of model capacity and provide a high-leverage target for task- or tenant-specific specialization~\cite{sfedus2022switch, schulman2025lora}. This combination is appealing from a deployment perspective: MoE reduces base-model compute, while LoRA enables efficient per-tenant customization without replicating the full model. However, it also creates a distinct serving regime in which dynamic sparse routing~\cite{gale2023megablocks} and long-tailed multi-tenant adaptation~\cite{} jointly determine which expert- and adapter-side weights are needed for each request, increasing access diversity and complicating locality management during inference.
+% v1: Large-scale LLM serving is increasingly shaped by the convergence of two trends that are each effective in isolation but jointly challenging in deployment: sparse Mixture-of-Experts (MoE) base models~\cite{jiang2024mixtral} and LoRA-based multi-tenant adaptation~\cite{hu2022lora,sheng2024slora}. In production settings, these trends naturally meet in \emph{multi-LoRA MoE serving}. While LoRA is widely used as a lightweight mechanism for tenant-specific customization, existing multi-LoRA serving systems have largely been designed for dense-model adaptation rather than expert-layer adaptation in sparse MoE models~\cite{chen2024punica,sheng2024slora}. Extending LoRA to MoE expert layers is both natural and practically important, because expert FFN blocks account for a large fraction of model capacity and provide a high-leverage target for task- or tenant-specific specialization~\cite{fedus2022switch, schulman2025lora}. This combination is appealing from a deployment perspective: MoE reduces base-model compute, while LoRA enables efficient per-tenant customization without replicating the full model. However, it also creates a distinct serving regime in which dynamic sparse routing~\cite{gale2023megablocks} and long-tailed multi-tenant adaptation~\cite{} jointly determine which expert- and adapter-side weights are needed for each request, increasing access diversity and complicating locality management during inference.
 
 This enlarged and more diverse working set becomes especially problematic during \emph{decode} in prefill--decode deployments~\cite{agrawal2023sarathi,patel2024splitwise}. Unlike prefill, which can often amortize weight-loading costs across many prompt tokens, decode operates under tight inter-token latency SLOs: generation is highly memory-bandwidth bound, and any weight miss on the critical path directly translates to pipeline stalls and ITL degradation. Consequently, the granularity of weight management becomes critical: in pure MoE serving, the natural unit is the expert; in conventional multi-LoRA serving, it is the adapter, and prior systems such as S-LoRA~\cite{sheng2024slora} and VaLoRA~\cite{mi2025empower} therefore adopt adapter-centric designs that assume dense adapter loading. 
 
@@ -496,10 +496,50 @@ Note:
 
 - compare CoLoRA against a ``skip-reinsert only'' variant (no deferred promotion/prefetch) to quantify the marginal gain of background optimizations under sustained cache pressure.~\ref{subsec:scheduler}
 
-\subsection{Microbenchmark Evaluations / Ablation Study}
-Note:
 
-- Measuring reinsertion latency (callback + D2H + state merge) and show it remains $<5\%$ of per-token decode time under typical cache pressure.~\ref{subsec:scheduler}
+\subsection{Microbenchmark Evaluation}
+\label{subsec:microbenchmark}
+
+\begin{figure}[h]
+  \centering
+  \includegraphics[width=\linewidth]{figures/fig_cold_recovery_singlecol.pdf}
+  \caption{
+  NOTE: placeholder!! Polish the layout and position after all data!!
+  Single-miss recovery microbenchmark at one MoE layer.
+  (a) Latency breakdown for representative decode configurations. Promotion-first is dominated by H2D transfer of the full expert--LoRA object, while execution-first moves only activation/residual-sized state and computes the missing LoRA residual on CPU.
+  (b) Speedup of execution-first over promotion-first across rank and batch-size sweeps. Execution-first achieves a 4.54$\times$ geometric mean speedup over 16 configurations, with larger gains when rank is high and decode batch size is small.
+  }
+\label{fig:microbreakdown}
+\end{figure}
+
+We first isolate the cost of recovering a single cold expert--LoRA miss at one MoE layer. This microbenchmark removes request scheduling, cache replacement, queueing, and cross-request overlap effects, and compares only the synchronous recovery work required by the current token. The goal is not to measure end-to-end serving performance, but to test whether execution-first recovery is a practical substrate for cold-miss handling.
+
+We compare two recovery policies. In promotion-first recovery, the runtime first restores the missing expert--LoRA object to GPU memory and then executes the LoRA residual on the GPU. In execution-first recovery, the runtime exports the current token activation to the host, computes only the missing LoRA residual on CPU using host-resident weights, and returns the residual for reintegration into the GPU decode stream. Thus, the two policies differ in what must be moved synchronously on the current token's critical path: promotion-first moves the full expert--LoRA object, whereas execution-first moves only activation- and residual-sized state.
+
+We decompose execution-first service time into packing, D2H activation transfer, CPU LoRA computation, H2D residual transfer, and merge. We decompose promotion-first service time into admission, H2D weight transfer, and GPU LoRA execution. This decomposition follows the latency model in Section~\ref{subsec:feasibility}: execution-first incurs
+\[
+T_{\mathrm{cold}} =
+T_{\mathrm{pack}} + T_{\mathrm{D2H}} + T_{\mathrm{cpu}} +
+T_{\mathrm{H2D}} + T_{\mathrm{merge}},
+\]
+whereas promotion-first incurs
+\[
+T_{\mathrm{promote}} =
+T_{\mathrm{admit}} + T_{\mathrm{H2D\text{-}weights}} + T_{\mathrm{gpu}}.
+\]
+We sweep LoRA rank $\{8,16,32,64\}$ and decode batch size $\{1,2,4,8\}$, covering the small-batch regime where decode stalls are most visible.
+
+
+Figure~\ref{fig:microbreakdown} reports the service time of one cold expert--LoRA miss. Across 16 rank/batch configurations, execution-first reduces recovery service time by a geometric mean of 4.54$\times$, with speedups ranging from 2.18$\times$ to 9.24$\times$. The breakdown shows that promotion-first is dominated by H2D transfer of the full expert--LoRA object, and this cost grows with rank. In contrast, execution-first transfers only the current activation and returned residual, so its data movement remains much smaller; the remaining cost is primarily CPU LoRA computation and staging overhead.
+
+These results support the core mechanism behind CoLoRA: for the current decode token, completing the missing LoRA residual can be substantially cheaper than first restoring GPU residency. This does not mean that CPU execution is generally faster than GPU execution. Rather, the advantage comes from changing the foreground recovery payload. Promotion-first pays the cost of restoring a full weight object before useful work can resume, while execution-first pays the cost of exchanging activation-sized state and computing only the missing residual.
+
+The experiment also exposes the boundary of the mechanism. As rank and batch size increase, CPU computation and staging overhead become more visible, reducing the margin over promotion-first. This is expected: execution-first targets cache-pressured decode regimes where cold misses have weak near-term reuse and the current token requires only a small amount of LoRA-side work. When reuse is strong enough to amortize promotion, or when cold-path CPU work becomes too large, promotion-first can become more competitive. Section~\ref{subsec:todo:} evaluates whether this per-miss advantage translates into lower TPOT under realistic mixed hit/miss workloads with scheduling, overlap, and cache pressure.
+
+\subsection{Ablation Study}
+% Note:
+
+% - Measuring reinsertion latency (callback + D2H + state merge) and show it remains $<5\%$ of per-token decode time under typical cache pressure.~\ref{subsec:scheduler}
 
 \subsection{Sensitivity Analysis}
 Note:

--- a/configs/evaluation/colora_kpi/microbench_config.yaml
+++ b/configs/evaluation/colora_kpi/microbench_config.yaml
@@ -1,0 +1,44 @@
+# P2 Cold Miss Recovery Microbenchmark Configuration
+#
+# Controls the single-layer MoE expert-LoRA decode cold-miss benchmark
+# that compares load_then_run (promotion-first) vs cpu_first (execution-first).
+
+hidden_size: 4096
+intermediate_size: 14336
+num_experts: 64
+topk: 8
+
+ranks:
+  - 8
+  - 16
+  - 32
+  - 64
+
+batch_sizes:
+  - 1
+  - 2
+  - 4
+  - 8
+
+dtype: fp16
+projection: gate
+
+repeats: 10
+warmup_iters: 10
+measurement_iters: 100
+
+cache_budget_mb: 64
+
+# CPU execution settings
+cpu_threads: 2
+cpu_kernel_mode: avx       # avx or naive
+numa_node: null             # null = auto; set to int for explicit binding
+
+# Expert cache
+promote_min_hits: 1
+promote_window: 16
+max_promote_per_step: 8
+decay: 0.9
+
+# Output
+output_dir: results/microbench_cold_recovery

--- a/lightllm/_kernels/lora/moe_lora_cpu_kernel.cpp
+++ b/lightllm/_kernels/lora/moe_lora_cpu_kernel.cpp
@@ -30,6 +30,15 @@
 
 using bf16 = c10::BFloat16;
 
+// Convert packed BF16 values to packed single-precision (FP32)
+// BF16 format is the upper 16 bits of FP32, so we just need to
+// unpack 16-bit values and shift left by 16 bits.
+inline __m512 _mm512_cvtbf16_ps(__m256i bf16_vec) {
+    __m512i int32_vec = _mm512_cvtepu16_epi32(bf16_vec);
+    __m512i shifted = _mm512_slli_epi32(int32_vec, 16);
+    return _mm512_castsi512_ps(shifted);
+}
+
 // Helper to detect optimal kernel type based on token count
 inline int get_optimal_kernel_type(int N) {
     if (N <= 2) {
@@ -43,12 +52,14 @@ inline int get_optimal_kernel_type(int N) {
     }
 }
 
-// Tiny kernel for N <= 2 - minimal overhead
+// Tiny kernel for N <= 2 - minimal overhead, optimized for single token
 void moe_lora_tiny_kernel(
     const bf16* x, const bf16* A_mat, const bf16* B_mat,
     bf16* out, int N, int H, int R, float scaling) {
 
-    // Use register blocking for minimal memory usage
+    float inter[128] = {0.0f};  // Support up to rank=128
+
+    // Stage 1: x[H] @ A^T[R,H] -> inter[R], fully vectorized with BF16 DP
     for (int n = 0; n < N; ++n) {
         const bf16* x_ptr = x + n * H;
 
@@ -58,8 +69,8 @@ void moe_lora_tiny_kernel(
 
             int k = 0;
             for (; k + 31 < H; k += 32) {
-                auto v_x = _mm512_loadu_si512((const __m512i*)(x_ptr + k));
-                auto v_A = _mm512_loadu_si512((const __m512i*)(A_ptr + k));
+                __m512i v_x = _mm512_loadu_si512((const __m512i*)(x_ptr + k));
+                __m512i v_A = _mm512_loadu_si512((const __m512i*)(A_ptr + k));
                 acc = _mm512_dpbf16_ps(acc, (__m512bh)v_x, (__m512bh)v_A);
             }
 
@@ -67,107 +78,100 @@ void moe_lora_tiny_kernel(
             for (; k < H; ++k) {
                 res += (float)x_ptr[k] * (float)A_ptr[k];
             }
+            inter[r] = res;
+        }
 
-            // Up projection for this rank
-            const bf16* B_ptr = B_mat + r * H;
-            __m512 up_acc = _mm512_setzero_ps();
-
-            int h = 0;
-            for (; h + 15 < H; h += 16) {
-                auto v_B = _mm256_loadu_si256((const __m256i*)(B_ptr + h));
-                up_acc = _mm512_fmadd_ps(_mm512_set1_ps(res * scaling),
-                                        _mm512_cvtph_ps(v_B), up_acc);
+        // Stage 2: inter[R] @ B[R,H] -> out[N,H], fully vectorized
+        // H dimension outer loop, accumulate all ranks into vector accumulator
+        bf16* out_ptr = out + n * H;
+        float out_f32[16];
+        int h = 0;
+        for (; h + 15 < H; h += 16) {
+            __m512 out_vec = _mm512_setzero_ps();
+            for (int r = 0; r < R; ++r) {
+                __m256i v_B = _mm256_loadu_si256((const __m256i*)(B_mat + r * H + h));
+                __m512 v_B_f32 = _mm512_cvtbf16_ps(v_B);
+                out_vec = _mm512_fmadd_ps(_mm512_set1_ps(inter[r] * scaling), v_B_f32, out_vec);
             }
-
-            float up_res_arr[16];
-            _mm256_storeu_ps(up_res_arr, _mm512_castps512_ps256(up_acc));
+            _mm512_storeu_ps(out_f32, out_vec);
             for (int i = 0; i < 16; ++i) {
-                if (h + i < H) {
-                    out[n * H + (h + i)] += bf16(up_res_arr[i]);
-                }
+                out_ptr[h + i] += bf16(out_f32[i]);
             }
+        }
 
-            for (; h < H; ++h) {
-                out[n * H + h] += bf16(res * scaling * (float)B_ptr[h]);
+        // Handle tail
+        for (; h < H; ++h) {
+            float acc = 0.0f;
+            for (int r = 0; r < R; ++r) {
+                acc += inter[r] * (float)B_mat[r * H + h] * scaling;
             }
+            out_ptr[h] += bf16(acc);
         }
     }
 }
 
-// Small kernel for N <= 8 - cache optimized
+// Small kernel for N <= 8 - cache optimized, AVX-512 BF16
 void moe_lora_small_kernel(
     const bf16* x, const bf16* A_mat, const bf16* B_mat,
     bf16* out, int N, int H, int R, float scaling) {
 
     const int cache_block_h = 128;
+    float inter[256];
 
     for (int n = 0; n < N; ++n) {
         const bf16* x_ptr = x + n * H;
+        bf16* out_ptr = out + n * H;
 
-        __m512 rank_acc[16];  // Rank blocking
-        for (int r = 0; r < std::min(R, 16); ++r) {
-            rank_acc[r] = _mm512_setzero_ps();
-        }
-
-        int k = 0;
-        for (; k + cache_block_h <= H; k += cache_block_h) {
-            const bf16* x_block = x_ptr + k;
-
-            for (int r = 0; r < std::min(R, 16); ++r) {
-                const bf16* A_ptr = A_mat + r * H + k;
-
-                int j = 0;
-                for (; j + 31 < cache_block_h; j += 32) {
-                    auto v_x = _mm512_loadu_si512((const __m512i*)(x_block + j));
-                    auto v_A = _mm512_loadu_si512((const __m512i*)(A_ptr + j));
-                    rank_acc[r] = _mm512_dpbf16_ps(rank_acc[r], (__m512bh)v_x, (__m512bh)v_A);
-                }
-
-                for (; j < cache_block_h; ++j) {
-                    float xv = (float)x_block[j];
-                    float av = (float)A_ptr[j];
-                    rank_acc[r][0] += xv * av;
-                }
-            }
-        }
-
-        // Process remaining H
-        for (int r = 0; r < std::min(R, 16); ++r) {
-            float res = _mm512_reduce_add_ps(rank_acc[r]);
-            for (; k < H; ++k) {
-                res += (float)x_ptr[k] * (float)A_mat[r * H + k];
-            }
-
-            // Up projection
-            const bf16* B_ptr = B_mat + r * H;
-            for (int h = 0; h < H; ++h) {
-                float contribution = res * scaling * (float)B_ptr[h];
-                out[n * H + h] += bf16(contribution);
-            }
-        }
-
-        // Handle remaining ranks
-        for (int r = 16; r < R; ++r) {
+        // Stage 1: x @ A^T -> inter[R]
+        for (int r = 0; r < R; ++r) {
             const bf16* A_ptr = A_mat + r * H;
             __m512 acc = _mm512_setzero_ps();
 
-            int kh = 0;
-            for (; kh + 31 < H; kh += 32) {
-                auto v_x = _mm512_loadu_si512((const __m512i*)(x_ptr + kh));
-                auto v_A = _mm512_loadu_si512((const __m512i*)(A_ptr + kh));
-                acc = _mm512_dpbf16_ps(acc, (__m512bh)v_x, (__m512bh)v_A);
+            int k = 0;
+            for (; k + cache_block_h <= H; k += cache_block_h) {
+                const bf16* x_block = x_ptr + k;
+                const bf16* A_block = A_ptr + k;
+
+                int j = 0;
+                for (; j + 31 < cache_block_h; j += 32) {
+                    __m512i v_x = _mm512_loadu_si512((const __m512i*)(x_block + j));
+                    __m512i v_A = _mm512_loadu_si512((const __m512i*)(A_block + j));
+                    acc = _mm512_dpbf16_ps(acc, (__m512bh)v_x, (__m512bh)v_A);
+                }
+
+                // Small cache block tail inside - handled by main loop
             }
 
             float res = _mm512_reduce_add_ps(acc);
-            for (; kh < H; ++kh) {
-                res += (float)x_ptr[kh] * (float)A_ptr[kh];
+            // Main H tail
+            for (; k < H; ++k) {
+                res += (float)x_ptr[k] * (float)A_mat[r * H + k];
             }
+            inter[r] = res;
+        }
 
-            const bf16* B_ptr = B_mat + r * H;
-            for (int h = 0; h < H; ++h) {
-                float contribution = res * scaling * (float)B_ptr[h];
-                out[n * H + h] += bf16(contribution);
+        // Stage 2: inter[R] @ B[R,H] -> out[n,H], fully vectorized
+        float out_f32[16];
+        int h = 0;
+        for (; h + 15 < H; h += 16) {
+            __m512 acc = _mm512_setzero_ps();
+            for (int r = 0; r < R; ++r) {
+                __m256i v_B = _mm256_loadu_si256((const __m256i*)(B_mat + r * H + h));
+                __m512 v_B_f32 = _mm512_cvtbf16_ps(v_B);
+                acc = _mm512_fmadd_ps(_mm512_set1_ps(inter[r] * scaling), v_B_f32, acc);
             }
+            _mm512_storeu_ps(out_f32, acc);
+            for (int i = 0; i < 16; ++i) {
+                out_ptr[h + i] += bf16(out_f32[i]);
+            }
+        }
+
+        for (; h < H; ++h) {
+            float acc = 0.0f;
+            for (int r = 0; r < R; ++r) {
+                acc += inter[r] * (float)B_mat[r * H + h] * scaling;
+            }
+            out_ptr[h] += bf16(acc);
         }
     }
 }
@@ -328,41 +332,89 @@ void moe_lora_gate_kernel(
     }
 }
 
-// Specialized kernel for Up phase of MoE
+// Specialized kernel for Up phase of MoE - AVX-512 BF16 optimized
 // Computes out[n,h] += sum_r x[n,r] * B[r,h] * scaling with B stored row-major [R, H].
-// (Prior SIMD path used _mm512_cvtph_ps on BF16 data and a broken tail loop; this
-// reference matches torch.matmul(x, B) * scaling in float32 reduce.)
 void moe_lora_up_kernel(
     const bf16* x, const bf16* B_mat, bf16* out,
     int N, int R, int H, float scaling) {
 
+    float x_f32[256];  // Pre-convert small R to f32
+
     #pragma omp parallel for schedule(dynamic, 2)
     for (int n = 0; n < N; ++n) {
         const bf16* x_ptr = x + n * R;
-        for (int hh = 0; hh < H; ++hh) {
-            float acc = 0.0f;
-            for (int rr = 0; rr < R; ++rr) {
-                acc += (float)x_ptr[rr] * (float)B_mat[rr * H + hh] * scaling;
+        bf16* out_ptr = out + n * H;
+
+        // Pre-convert x[n,r] to float once (R is small, ~8-64)
+        for (int r = 0; r < R; ++r) {
+            x_f32[r] = (float)x_ptr[r];  // NOTE: scaling applied below
+        }
+
+        // H dimension outer loop: fully vectorized with 16-way SIMD
+        float out_f32[16];
+        int h = 0;
+        for (; h + 15 < H; h += 16) {
+            __m512 acc = _mm512_setzero_ps();
+            for (int r = 0; r < R; ++r) {
+                __m256i v_B = _mm256_loadu_si256((const __m256i*)(B_mat + r * H + h));
+                __m512 v_B_f32 = _mm512_cvtbf16_ps(v_B);
+                acc = _mm512_fmadd_ps(_mm512_set1_ps(x_f32[r] * scaling), v_B_f32, acc);
             }
-            out[n * H + hh] += bf16(acc);
+            _mm512_storeu_ps(out_f32, acc);
+            for (int i = 0; i < 16; ++i) {
+                out_ptr[h + i] += bf16(out_f32[i]);
+            }
+        }
+
+        // Handle remaining H elements (tail)
+        for (; h < H; ++h) {
+            float acc = 0.0f;
+            for (int r = 0; r < R; ++r) {
+                acc += x_f32[r] * (float)B_mat[r * H + h] * scaling;
+            }
+            out_ptr[h] += bf16(acc);
         }
     }
 }
 
 // Same layout/matmul as moe_lora_up_kernel (down uses identical [N,R]@[R,H]->[N,H] here).
+// AVX-512 BF16 optimized version.
 void moe_lora_down_kernel(
     const bf16* x, const bf16* B_mat, bf16* out,
     int N, int R, int H, float scaling) {
 
+    float x_f32[256];
+
     #pragma omp parallel for schedule(dynamic, 1)
     for (int n = 0; n < N; ++n) {
         const bf16* x_ptr = x + n * R;
-        for (int hh = 0; hh < H; ++hh) {
-            float acc = 0.0f;
-            for (int rr = 0; rr < R; ++rr) {
-                acc += (float)x_ptr[rr] * (float)B_mat[rr * H + hh] * scaling;
+        bf16* out_ptr = out + n * H;
+
+        for (int r = 0; r < R; ++r) {
+            x_f32[r] = (float)x_ptr[r];
+        }
+
+        float out_f32[16];
+        int h = 0;
+        for (; h + 15 < H; h += 16) {
+            __m512 acc = _mm512_setzero_ps();
+            for (int r = 0; r < R; ++r) {
+                __m256i v_B = _mm256_loadu_si256((const __m256i*)(B_mat + r * H + h));
+                __m512 v_B_f32 = _mm512_cvtbf16_ps(v_B);
+                acc = _mm512_fmadd_ps(_mm512_set1_ps(x_f32[r] * scaling), v_B_f32, acc);
             }
-            out[n * H + hh] += bf16(acc);
+            _mm512_storeu_ps(out_f32, acc);
+            for (int i = 0; i < 16; ++i) {
+                out_ptr[h + i] += bf16(out_f32[i]);
+            }
+        }
+
+        for (; h < H; ++h) {
+            float acc = 0.0f;
+            for (int r = 0; r < R; ++r) {
+                acc += x_f32[r] * (float)B_mat[r * H + h] * scaling;
+            }
+            out_ptr[h] += bf16(acc);
         }
     }
 }
@@ -426,6 +478,276 @@ void moe_batch_lora_down_avx(
     moe_lora_dispatch(x, nullptr, B_mat, out, N, H, R, scaling, "down");
 }
 
+// Multi-adapter batched kernel: each token can use a different adapter's weights.
+// This eliminates Python per-adapter loop overhead for cold-miss scenarios.
+//
+// x: [N, H] input (all tokens concatenated)
+// A_all: [num_adapters, R, H] stacked A matrices
+// B_all: [num_adapters, R, H] stacked B matrices
+// adapter_ids: [N] int tensor mapping each token to its adapter index (0-based)
+// scaling: [num_adapters] per-adapter scaling factors (or nullptr for uniform scaling)
+// out: [N, H] output (pre-allocated, zeroed)
+// N, H, R, num_adapters: dimensions
+// uniform_scaling: if > 0, use this for all adapters (ignores scaling array)
+void moe_lora_multi_adapter_avx(
+    const bf16* x, const bf16* A_all, const bf16* B_all,
+    const int* adapter_ids, const float* scaling,
+    bf16* out, int N, int H, int R, int num_adapters,
+    float uniform_scaling) {
+
+    // Use the per-token gate+up approach, but all in C++ to avoid Python overhead
+    #pragma omp parallel for schedule(dynamic, 2) if(N > 4)
+    for (int n = 0; n < N; ++n) {
+        int adapter_idx = adapter_ids[n];
+        if (adapter_idx < 0 || adapter_idx >= num_adapters) continue;
+
+        const bf16* x_ptr = x + n * H;
+        const bf16* A_mat = A_all + adapter_idx * R * H;
+        const bf16* B_mat = B_all + adapter_idx * R * H;
+        bf16* out_ptr = out + n * H;
+
+        float s = (uniform_scaling > 0.0f) ? uniform_scaling : scaling[adapter_idx];
+
+        // Stage 1: x[H] @ A^T[R,H] -> inter[R]
+        float inter[128];  // max rank 128
+        for (int r = 0; r < R; ++r) {
+            const bf16* A_ptr = A_mat + r * H;
+            __m512 acc = _mm512_setzero_ps();
+            int k = 0;
+            for (; k + 31 < H; k += 32) {
+                __m512i v_x = _mm512_loadu_si512((const __m512i*)(x_ptr + k));
+                __m512i v_A = _mm512_loadu_si512((const __m512i*)(A_ptr + k));
+                acc = _mm512_dpbf16_ps(acc, (__m512bh)v_x, (__m512bh)v_A);
+            }
+            float res = _mm512_reduce_add_ps(acc);
+            for (; k < H; ++k) {
+                res += (float)x_ptr[k] * (float)A_ptr[k];
+            }
+            inter[r] = res;
+        }
+
+        // Stage 2: inter[R] @ B[R,H] -> out[H]
+        float out_f32[16];
+        int h = 0;
+        for (; h + 15 < H; h += 16) {
+            __m512 out_vec = _mm512_setzero_ps();
+            for (int r = 0; r < R; ++r) {
+                __m256i v_B = _mm256_loadu_si256((const __m256i*)(B_mat + r * H + h));
+                __m512 v_B_f32 = _mm512_cvtbf16_ps(v_B);
+                out_vec = _mm512_fmadd_ps(_mm512_set1_ps(inter[r] * s), v_B_f32, out_vec);
+            }
+            _mm512_storeu_ps(out_f32, out_vec);
+            for (int i = 0; i < 16; ++i) {
+                out_ptr[h + i] = bf16(out_f32[i]);
+            }
+        }
+        for (; h < H; ++h) {
+            float acc = 0.0f;
+            for (int r = 0; r < R; ++r) {
+                acc += inter[r] * (float)B_mat[r * H + h] * s;
+            }
+            out_ptr[h] = bf16(acc);
+        }
+    }
+}
+
+// Pool-based multi-adapter kernel: accepts the pool buffer directly with per-adapter
+// offset/rank information, avoiding any tensor copying in Python.
+//
+// key_buffer: pool key_buffer [total_slots, max_rank, H] (CPU, bf16)
+// value_buffer: pool value_buffer [total_slots, max_rank, H] (CPU, bf16)
+// x: [N, H] input (CPU, bf16)
+// out: [N, H] output (pre-allocated, zeroed, CPU, bf16)
+// adapter_ids: [N] int per-token adapter index in the pool (0-based)
+// pool_offsets: [num_unique] int per-unique-adapter offset into key/value_buffer
+// pool_ranks: [num_unique] int per-unique-adapter rank
+// pool_scaling: [num_unique] float per-unique-adapter scaling (or nullptr)
+// adapter_local_ids: [N] int mapping token to index in pool_offsets/ranks/scaling
+//   (adapter_ids in the pool, remapped to 0..num_unique-1)
+void moe_lora_pool_multi_adapter_avx(
+    const bf16* key_buffer, const bf16* value_buffer,
+    const bf16* x, bf16* out,
+    const int* adapter_local_ids,
+    const int* pool_offsets, const int* pool_ranks, const float* pool_scaling,
+    int N, int H, int max_rank, int num_unique,
+    float uniform_scaling) {
+
+    #pragma omp parallel for schedule(dynamic, 2) if(N > 4)
+    for (int n = 0; n < N; ++n) {
+        int local_id = adapter_local_ids[n];
+        if (local_id < 0 || local_id >= num_unique) continue;
+
+        const bf16* x_ptr = x + n * H;
+        int offset = pool_offsets[local_id];
+        int R = pool_ranks[local_id];
+        float s = (uniform_scaling > 0.0f) ? uniform_scaling : pool_scaling[local_id];
+
+        const bf16* A_mat = key_buffer + offset * max_rank * H;
+        const bf16* B_mat = value_buffer + offset * max_rank * H;
+        bf16* out_ptr = out + n * H;
+
+        // Stage 1: x[H] @ A^T[R,H] -> inter[R]
+        float inter[128];
+        for (int r = 0; r < R; ++r) {
+            const bf16* A_ptr = A_mat + r * H;
+            __m512 acc = _mm512_setzero_ps();
+            int k = 0;
+            for (; k + 31 < H; k += 32) {
+                __m512i v_x = _mm512_loadu_si512((const __m512i*)(x_ptr + k));
+                __m512i v_A = _mm512_loadu_si512((const __m512i*)(A_ptr + k));
+                acc = _mm512_dpbf16_ps(acc, (__m512bh)v_x, (__m512bh)v_A);
+            }
+            float res = _mm512_reduce_add_ps(acc);
+            for (; k < H; ++k) {
+                res += (float)x_ptr[k] * (float)A_ptr[k];
+            }
+            inter[r] = res;
+        }
+
+        // Stage 2: inter[R] @ B[R,H] -> out[H]
+        float out_f32[16];
+        int h = 0;
+        for (; h + 15 < H; h += 16) {
+            __m512 out_vec = _mm512_setzero_ps();
+            for (int r = 0; r < R; ++r) {
+                __m256i v_B = _mm256_loadu_si256((const __m256i*)(B_mat + r * H + h));
+                __m512 v_B_f32 = _mm512_cvtbf16_ps(v_B);
+                out_vec = _mm512_fmadd_ps(_mm512_set1_ps(inter[r] * s), v_B_f32, out_vec);
+            }
+            _mm512_storeu_ps(out_f32, out_vec);
+            for (int i = 0; i < 16; ++i) {
+                out_ptr[h + i] = bf16(out_f32[i]);
+            }
+        }
+        for (; h < H; ++h) {
+            float acc = 0.0f;
+            for (int r = 0; r < R; ++r) {
+                acc += inter[r] * (float)B_mat[r * H + h] * s;
+            }
+            out_ptr[h] = bf16(acc);
+        }
+    }
+}
+
+// FP16 pool multi-adapter kernel: reads fp16 weights from pool, converts to fp32
+// on the fly using AVX-512 FP16 conversion, and uses AVX-512 FMA for matmul.
+// Input x is still bf16 (activation on CPU), output is bf16.
+//
+// key_buffer: pool key_buffer [total_slots, max_rank, H] (CPU, fp16)
+// value_buffer: pool value_buffer [total_slots, max_rank, H] (CPU, fp16)
+// x: [N, H] input (CPU, bf16)
+// out: [N, H] output (pre-allocated, zeroed, CPU, bf16)
+void moe_lora_pool_fp16_multi_adapter_avx(
+    const uint16_t* key_buffer, const uint16_t* value_buffer,  // fp16 as uint16_t
+    const bf16* x, bf16* out,
+    const int* adapter_local_ids,
+    const int* pool_offsets, const int* pool_ranks, const float* pool_scaling,
+    int N, int H, int max_rank, int num_unique,
+    float uniform_scaling) {
+
+    #pragma omp parallel for schedule(dynamic, 2) if(N > 4)
+    for (int n = 0; n < N; ++n) {
+        int local_id = adapter_local_ids[n];
+        if (local_id < 0 || local_id >= num_unique) continue;
+
+        const bf16* x_ptr = x + n * H;
+        int offset = pool_offsets[local_id];
+        int R = pool_ranks[local_id];
+        float s = (uniform_scaling > 0.0f) ? uniform_scaling : pool_scaling[local_id];
+
+        const uint16_t* A_mat = key_buffer + offset * max_rank * H;
+        const uint16_t* B_mat = value_buffer + offset * max_rank * H;
+        bf16* out_ptr = out + n * H;
+
+        // Stage 1: x[H] @ A^T[R,H] -> inter[R]
+        // x is bf16, A is fp16 — need to convert both to fp32 for FMA
+        // Since x is shared across all ranks, pre-convert x to fp32
+        // H=4096 elements × 4 bytes = 16KB, fits in L1 cache
+        float x_f32[4096];  // VLA, max H=4096
+        int k = 0;
+        for (; k + 15 < H; k += 16) {
+            __m256i v_x_bf16 = _mm256_loadu_si256((const __m256i*)(x_ptr + k));
+            __m512 v_x_f32 = _mm512_cvtbf16_ps(v_x_bf16);
+            _mm512_storeu_ps(x_f32 + k, v_x_f32);
+        }
+        for (; k < H; ++k) {
+            x_f32[k] = (float)x_ptr[k];
+        }
+
+        float inter[128];
+        for (int r = 0; r < R; ++r) {
+            const uint16_t* A_ptr = A_mat + r * H;
+            __m512 acc = _mm512_setzero_ps();
+            int j = 0;
+            // Process 16 elements at a time: load 16 fp16, convert to fp32, FMA
+            for (; j + 15 < H; j += 16) {
+                __m256i v_A_fp16 = _mm256_loadu_si256((const __m256i*)(A_ptr + j));
+                __m512 v_A_f32 = _mm256_cvtph_ps(v_A_fp16);  // F16C: fp16 -> fp32
+                __m512 v_x = _mm512_loadu_ps(x_f32 + j);
+                acc = _mm512_fmadd_ps(v_x, v_A_f32, acc);
+            }
+            float res = _mm512_reduce_add_ps(acc);
+            for (; j < H; ++j) {
+                // Manual fp16 -> fp32 for tail
+                uint16_t h = A_ptr[j];
+                uint32_t sign = (h >> 15) & 1;
+                uint32_t exponent = (h >> 10) & 0x1f;
+                uint32_t mantissa = h & 0x3ff;
+                float val;
+                if (exponent == 0) {
+                    if (mantissa == 0) val = 0.0f;
+                    else val = ldexpf((float)mantissa / 1024.0f, -14);
+                } else if (exponent == 31) {
+                    val = mantissa ? NAN : (sign ? -INFINITY : INFINITY);
+                } else {
+                    val = ldexpf(1.0f + (float)mantissa / 1024.0f, (int)exponent - 15);
+                }
+                if (sign) val = -val;
+                res += x_f32[j] * val;
+            }
+            inter[r] = res;
+        }
+
+        // Stage 2: inter[R] @ B[R,H] -> out[H]
+        // B is fp16, convert to fp32 for FMA
+        float out_f32[16];
+        int h = 0;
+        for (; h + 15 < H; h += 16) {
+            __m512 out_vec = _mm512_setzero_ps();
+            for (int r = 0; r < R; ++r) {
+                __m256i v_B_fp16 = _mm256_loadu_si256((const __m256i*)(B_mat + r * H + h));
+                __m512 v_B_f32 = _mm256_cvtph_ps(v_B_fp16);
+                out_vec = _mm512_fmadd_ps(_mm512_set1_ps(inter[r] * s), v_B_f32, out_vec);
+            }
+            _mm512_storeu_ps(out_f32, out_vec);
+            for (int i = 0; i < 16; ++i) {
+                out_ptr[h + i] = bf16(out_f32[i]);
+            }
+        }
+        for (; h < H; ++h) {
+            float acc = 0.0f;
+            for (int r = 0; r < R; ++r) {
+                uint16_t raw = B_mat[r * H + h];
+                uint32_t sign = (raw >> 15) & 1;
+                uint32_t exponent = (raw >> 10) & 0x1f;
+                uint32_t mantissa = raw & 0x3ff;
+                float val;
+                if (exponent == 0) {
+                    if (mantissa == 0) val = 0.0f;
+                    else val = ldexpf((float)mantissa / 1024.0f, -14);
+                } else if (exponent == 31) {
+                    val = mantissa ? NAN : (sign ? -INFINITY : INFINITY);
+                } else {
+                    val = ldexpf(1.0f + (float)mantissa / 1024.0f, (int)exponent - 15);
+                }
+                if (sign) val = -val;
+                acc += inter[r] * val * s;
+            }
+            out_ptr[h] = bf16(acc);
+        }
+    }
+}
+
 // Python bindings
 PYBIND11_MODULE(moe_lora_cpu_kernel, m) {
     m.def("moe_batch_lora_avx", [](
@@ -472,6 +794,70 @@ PYBIND11_MODULE(moe_lora_cpu_kernel, m) {
             N, H, R, scaling
         );
     }, "MoE Down phase AVX-512 LoRA kernel");
+
+    m.def("moe_lora_multi_adapter_avx", [](
+        const at::Tensor& x, const at::Tensor& A_all, const at::Tensor& B_all,
+        const at::Tensor& adapter_ids, const at::Tensor& scaling,
+        at::Tensor& out, int N, int H, int R, int num_adapters,
+        float uniform_scaling) {
+        const float* scaling_ptr = (scaling.numel() > 0 && uniform_scaling <= 0.0f)
+            ? scaling.data_ptr<float>() : nullptr;
+        moe_lora_multi_adapter_avx(
+            reinterpret_cast<const bf16*>(x.data_ptr()),
+            reinterpret_cast<const bf16*>(A_all.data_ptr()),
+            reinterpret_cast<const bf16*>(B_all.data_ptr()),
+            adapter_ids.data_ptr<int>(),
+            scaling_ptr,
+            reinterpret_cast<bf16*>(out.data_ptr()),
+            N, H, R, num_adapters, uniform_scaling
+        );
+    }, "Multi-adapter batched AVX-512 LoRA kernel");
+
+    m.def("moe_lora_pool_multi_adapter_avx", [](
+        const at::Tensor& key_buffer, const at::Tensor& value_buffer,
+        const at::Tensor& x, at::Tensor& out,
+        const at::Tensor& adapter_local_ids,
+        const at::Tensor& pool_offsets, const at::Tensor& pool_ranks,
+        const at::Tensor& pool_scaling,
+        int N, int H, int max_rank, int num_unique,
+        float uniform_scaling) {
+        const float* scaling_ptr = (pool_scaling.numel() > 0 && uniform_scaling <= 0.0f)
+            ? pool_scaling.data_ptr<float>() : nullptr;
+        moe_lora_pool_multi_adapter_avx(
+            reinterpret_cast<const bf16*>(key_buffer.data_ptr()),
+            reinterpret_cast<const bf16*>(value_buffer.data_ptr()),
+            reinterpret_cast<const bf16*>(x.data_ptr()),
+            reinterpret_cast<bf16*>(out.data_ptr()),
+            adapter_local_ids.data_ptr<int>(),
+            pool_offsets.data_ptr<int>(),
+            pool_ranks.data_ptr<int>(),
+            scaling_ptr,
+            N, H, max_rank, num_unique, uniform_scaling
+        );
+    }, "Pool-based multi-adapter batched AVX-512 LoRA kernel");
+
+    m.def("moe_lora_pool_fp16_multi_adapter_avx", [](
+        const at::Tensor& key_buffer, const at::Tensor& value_buffer,
+        const at::Tensor& x, at::Tensor& out,
+        const at::Tensor& adapter_local_ids,
+        const at::Tensor& pool_offsets, const at::Tensor& pool_ranks,
+        const at::Tensor& pool_scaling,
+        int N, int H, int max_rank, int num_unique,
+        float uniform_scaling) {
+        const float* scaling_ptr = (pool_scaling.numel() > 0 && uniform_scaling <= 0.0f)
+            ? pool_scaling.data_ptr<float>() : nullptr;
+        moe_lora_pool_fp16_multi_adapter_avx(
+            reinterpret_cast<const uint16_t*>(key_buffer.data_ptr()),
+            reinterpret_cast<const uint16_t*>(value_buffer.data_ptr()),
+            reinterpret_cast<const bf16*>(x.data_ptr()),
+            reinterpret_cast<bf16*>(out.data_ptr()),
+            adapter_local_ids.data_ptr<int>(),
+            pool_offsets.data_ptr<int>(),
+            pool_ranks.data_ptr<int>(),
+            scaling_ptr,
+            N, H, max_rank, num_unique, uniform_scaling
+        );
+    }, "Pool-based multi-adapter batched AVX-512 LoRA kernel (fp16 weights)");
 
     m.def("is_available", []() {
         // Check if AVX-512 BF16 instructions are available

--- a/lightllm/_kernels/lora/moe_lora_cpu_kernel.cpp
+++ b/lightllm/_kernels/lora/moe_lora_cpu_kernel.cpp
@@ -338,10 +338,10 @@ void moe_lora_up_kernel(
     const bf16* x, const bf16* B_mat, bf16* out,
     int N, int R, int H, float scaling) {
 
-    float x_f32[256];  // Pre-convert small R to f32
-
     #pragma omp parallel for schedule(dynamic, 2)
     for (int n = 0; n < N; ++n) {
+        float x_f32[256];
+
         const bf16* x_ptr = x + n * R;
         bf16* out_ptr = out + n * H;
 
@@ -383,10 +383,10 @@ void moe_lora_down_kernel(
     const bf16* x, const bf16* B_mat, bf16* out,
     int N, int R, int H, float scaling) {
 
-    float x_f32[256];
-
     #pragma omp parallel for schedule(dynamic, 1)
     for (int n = 0; n < N; ++n) {
+        float x_f32[256];
+
         const bf16* x_ptr = x + n * R;
         bf16* out_ptr = out + n * H;
 

--- a/lightllm/_kernels/lora/moe_lora_cpu_kernel.py
+++ b/lightllm/_kernels/lora/moe_lora_cpu_kernel.py
@@ -177,3 +177,140 @@ def moe_batch_lora_down_avx(
         x.shape[0], x.shape[1], B.shape[1], scaling
     )
     return output
+
+
+def moe_lora_multi_adapter_avx(
+    x: torch.Tensor,
+    A_all: torch.Tensor,
+    B_all: torch.Tensor,
+    adapter_ids: torch.Tensor,
+    scaling: torch.Tensor,
+    uniform_scaling: float = 0.0,
+) -> torch.Tensor:
+    """Batched multi-adapter LoRA: each token uses its own adapter's weights.
+
+    Eliminates Python per-adapter loop overhead by running the entire
+    gate+up computation in a single C++ kernel call.
+
+    Args:
+        x: Input tensor [N, H]
+        A_all: Stacked A matrices [num_adapters, R, H]
+        B_all: Stacked B matrices [num_adapters, R, H]
+        adapter_ids: Per-token adapter index [N] (0-based LongTensor, CPU)
+        scaling: Per-adapter scaling [num_adapters] (FloatTensor, CPU)
+        uniform_scaling: If > 0, use this for all adapters (ignore scaling tensor)
+
+    Returns:
+        LoRA output [N, H]
+    """
+    ensure_kernel_loaded()
+    if _moe_lora_cpu_kernel is None:
+        raise RuntimeError("moe_lora_cpu_kernel extension failed to load")
+    N = x.shape[0]
+    H = x.shape[1]
+    R = A_all.shape[1]
+    num_adapters = A_all.shape[0]
+    output = torch.zeros(N, H, dtype=x.dtype, device=x.device)
+    # C++ binding expects int32 for adapter_ids
+    _adapter_ids_i32 = adapter_ids.to(dtype=torch.int32) if adapter_ids.dtype != torch.int32 else adapter_ids
+    _moe_lora_cpu_kernel.moe_lora_multi_adapter_avx(
+        x, A_all, B_all, _adapter_ids_i32, scaling, output,
+        N, H, R, num_adapters, uniform_scaling,
+    )
+    return output
+
+
+def moe_lora_pool_multi_adapter_avx(
+    key_buffer: torch.Tensor,
+    value_buffer: torch.Tensor,
+    x: torch.Tensor,
+    adapter_local_ids: torch.Tensor,
+    pool_offsets: torch.Tensor,
+    pool_ranks: torch.Tensor,
+    pool_scaling: torch.Tensor,
+    uniform_scaling: float = 0.0,
+) -> torch.Tensor:
+    """Pool-based multi-adapter LoRA: reads directly from pool buffers.
+
+    Avoids any tensor stacking/copying — reads A/B from the pool's
+    key_buffer/value_buffer using per-adapter offsets.
+
+    Args:
+        key_buffer: Pool key_buffer [total_slots, max_rank, H] (CPU bf16)
+        value_buffer: Pool value_buffer [total_slots, max_rank, H] (CPU bf16)
+        x: Input tensor [N, H] (CPU bf16)
+        adapter_local_ids: Per-token local adapter ID [N] (int32, CPU)
+            Maps each token to its index in pool_offsets/pool_ranks/pool_scaling.
+        pool_offsets: Per-adapter slot offset [num_unique] (int32, CPU)
+        pool_ranks: Per-adapter rank [num_unique] (int32, CPU)
+        pool_scaling: Per-adapter scaling [num_unique] (float32, CPU)
+        uniform_scaling: If > 0, use for all adapters
+
+    Returns:
+        LoRA output [N, H] (CPU bf16)
+    """
+    ensure_kernel_loaded()
+    if _moe_lora_cpu_kernel is None:
+        raise RuntimeError("moe_lora_cpu_kernel extension failed to load")
+    N = x.shape[0]
+    H = x.shape[1]
+    max_rank = key_buffer.shape[1]
+    num_unique = pool_offsets.shape[0]
+    output = torch.zeros(N, H, dtype=x.dtype, device=x.device)
+    _local_ids_i32 = adapter_local_ids.to(dtype=torch.int32) if adapter_local_ids.dtype != torch.int32 else adapter_local_ids
+    _offsets_i32 = pool_offsets.to(dtype=torch.int32) if pool_offsets.dtype != torch.int32 else pool_offsets
+    _ranks_i32 = pool_ranks.to(dtype=torch.int32) if pool_ranks.dtype != torch.int32 else pool_ranks
+    _moe_lora_cpu_kernel.moe_lora_pool_multi_adapter_avx(
+        key_buffer, value_buffer, x, output,
+        _local_ids_i32, _offsets_i32, _ranks_i32, pool_scaling,
+        N, H, max_rank, num_unique, uniform_scaling,
+    )
+    return output
+
+
+def moe_lora_pool_fp16_multi_adapter_avx(
+    key_buffer: torch.Tensor,
+    value_buffer: torch.Tensor,
+    x: torch.Tensor,
+    adapter_local_ids: torch.Tensor,
+    pool_offsets: torch.Tensor,
+    pool_ranks: torch.Tensor,
+    pool_scaling: torch.Tensor,
+    uniform_scaling: float = 0.0,
+) -> torch.Tensor:
+    """Pool-based multi-adapter LoRA with fp16 weights.
+
+    Reads fp16 weights from pool buffers directly, converts to fp32
+    on-the-fly using F16C instructions. Input x is bf16 (activation),
+    output is bf16. No tensor copying or stacking in Python.
+
+    Args:
+        key_buffer: Pool key_buffer [total_slots, max_rank, H] (CPU fp16)
+        value_buffer: Pool value_buffer [total_slots, max_rank, H] (CPU fp16)
+        x: Input tensor [N, H] (CPU bf16)
+        adapter_local_ids: Per-token local adapter ID [N] (int32, CPU)
+        pool_offsets: Per-adapter slot offset [num_unique] (int32, CPU)
+        pool_ranks: Per-adapter rank [num_unique] (int32, CPU)
+        pool_scaling: Per-adapter scaling [num_unique] (float32, CPU)
+        uniform_scaling: If > 0, use for all adapters
+
+    Returns:
+        LoRA output [N, H] (CPU bf16)
+    """
+    ensure_kernel_loaded()
+    if _moe_lora_cpu_kernel is None:
+        raise RuntimeError("moe_lora_cpu_kernel extension failed to load")
+    N = x.shape[0]
+    H = x.shape[1]
+    max_rank = key_buffer.shape[1]
+    num_unique = pool_offsets.shape[0]
+    output = torch.zeros(N, H, dtype=x.dtype, device=x.device)
+    _local_ids_i32 = adapter_local_ids.to(dtype=torch.int32) if adapter_local_ids.dtype != torch.int32 else adapter_local_ids
+    _offsets_i32 = pool_offsets.to(dtype=torch.int32) if pool_offsets.dtype != torch.int32 else pool_offsets
+    _ranks_i32 = pool_ranks.to(dtype=torch.int32) if pool_ranks.dtype != torch.int32 else pool_ranks
+    _moe_lora_cpu_kernel.moe_lora_pool_fp16_multi_adapter_avx(
+        key_buffer, value_buffer, x, output,
+        _local_ids_i32, _offsets_i32, _ranks_i32, pool_scaling,
+        N, H, max_rank, num_unique, uniform_scaling,
+    )
+    return output

--- a/lightllm/models/qwen3_vl_moe/lora_dispatch.py
+++ b/lightllm/models/qwen3_vl_moe/lora_dispatch.py
@@ -100,6 +100,7 @@ except ImportError:
 
 try:
     from lightllm._kernels.lora.moe_lora_cpu_kernel import (
+        moe_batch_lora_avx,
         moe_batch_lora_gate_avx,
         moe_batch_lora_up_avx,
         moe_batch_lora_down_avx,
@@ -348,6 +349,12 @@ class _MoEHybridPhaseState:
     blocking_promotion_time: float = 0.0
     blocking_promotion_bytes: float = 0.0
     blocking_promotion_count: int = 0
+    # P2 microbench component timings (seconds)
+    pack_time: float = 0.0
+    d2h_activation_time: float = 0.0
+    h2d_residual_time: float = 0.0
+    merge_time: float = 0.0
+    admit_time: float = 0.0
 
 
 @dataclass
@@ -905,6 +912,11 @@ class Qwen3VLMoELoRADispatcher:
             "prefetch_stale": 0,
             "prefetch_false_positives": 0,
             "prefetch_slot_overwrite": 0,
+            "pack_time": 0.0,
+            "d2h_activation_time": 0.0,
+            "h2d_residual_time": 0.0,
+            "merge_time": 0.0,
+            "admit_time": 0.0,
         }
 
         # Check if any LoRA is enabled
@@ -1364,7 +1376,15 @@ class Qwen3VLMoELoRADispatcher:
         return_to_original_device: bool = True,
         temporal_prefetch_context: Optional[Tuple[int, int, int]] = None,
     ) -> Tuple[torch.Tensor, int, int]:
-        """Strict MoE CPU fallback: AVX MoE kernels or PyTorch reference (``naive``)."""
+        """Strict MoE CPU fallback: AVX MoE kernels or PyTorch reference (``naive``).
+        
+        Returns: (output, kernel_calls, kernel_tokens)
+        
+        Note: Timing is tracked internally in self._last_colora_stats:
+            - d2h_activation_time: input D2H transfer (if input was on CUDA)
+            - h2d_residual_time: output H2D transfer (if returning to CUDA)
+            Both happen OUTSIDE cpu_compute_time measurement in the caller.
+        """
         cpu_kernel_mode = _colora_resolved_cpu_kernel_mode()
         if cpu_kernel_mode != "naive":
             self._require_moe_cpu_kernel(mode=projection)
@@ -1381,15 +1401,25 @@ class Qwen3VLMoELoRADispatcher:
             original_dtype = input_tensor.dtype
 
             with NvtxAnnotate(f"{nvtx_root}/HostTensorPrep"):
+                _d2h_t0 = time.perf_counter()
                 compute_input = input_tensor
                 if compute_input.device.type != "cpu":
                     compute_input = compute_input.to(device="cpu", non_blocking=True)
-                if compute_input.dtype != torch.bfloat16:
-                    compute_input = compute_input.to(dtype=torch.bfloat16)
+                # For naive mode: convert directly to float32 upfront (faster CPU compute)
+                if cpu_kernel_mode == "naive":
+                    if compute_input.dtype != torch.float32:
+                        compute_input = compute_input.to(dtype=torch.float32)
+                else:
+                    if compute_input.dtype != torch.bfloat16:
+                        compute_input = compute_input.to(dtype=torch.bfloat16)
+                if input_tensor.device.type != "cpu":
+                    self._last_colora_stats["d2h_activation_time"] += max(time.perf_counter() - _d2h_t0, 0.0)
 
             batch_size = compute_input.shape[0]
             output_dim = pool.value_buffer.shape[2]
-            output = torch.zeros(batch_size, output_dim, dtype=torch.bfloat16, device="cpu")
+            # Use float32 for naive mode output (faster matmul, converts once at H2D)
+            output_dtype = torch.float32 if cpu_kernel_mode == "naive" else torch.bfloat16
+            output = torch.zeros(batch_size, output_dim, dtype=output_dtype, device="cpu")
 
             if len(req_bins) > batch_size:
                 req_bins = req_bins[:batch_size]
@@ -1461,10 +1491,13 @@ class Qwen3VLMoELoRADispatcher:
                             B = pool.value_buffer[loc, :a_rank]
 
                         with NvtxAnnotate(f"{adapter_nvtx}/WeightHostPrep"):
-                            if A.device.type != "cpu" or A.dtype != torch.bfloat16:
-                                A = A.to(device="cpu", dtype=torch.bfloat16)
-                            if B.device.type != "cpu" or B.dtype != torch.bfloat16:
-                                B = B.to(device="cpu", dtype=torch.bfloat16)
+                            # For naive mode, convert directly to float32 for faster matmul
+                            # (bf16 CPU matmul is very slow without AVX-512 BF16 support)
+                            target_dtype = torch.float32 if cpu_kernel_mode == "naive" else torch.bfloat16
+                            if A.dtype != target_dtype:
+                                A = A.to(dtype=target_dtype)
+                            if B.dtype != target_dtype:
+                                B = B.to(dtype=target_dtype)
                             if not A.is_contiguous():
                                 A = A.contiguous()
                             if not B.is_contiguous():
@@ -1474,23 +1507,39 @@ class Qwen3VLMoELoRADispatcher:
                             if not batch_input.is_contiguous():
                                 batch_input = batch_input.contiguous()
 
-                        # Stage-1: x @ A^T (naive matmul or AVX gate path)
-                        with NvtxAnnotate(f"{adapter_nvtx}/Stage1_{cpu_kernel_mode}_gate"):
-                            intermediate = gate_kernel(batch_input, A, 1.0)
-                        # Stage-2: intermediate @ B, projection-specific kernel.
-                        with NvtxAnnotate(f"{adapter_nvtx}/Stage2_{cpu_kernel_mode}_{proj_lower}"):
-                            batch_output = stage2_kernel(intermediate, B, scaling=a_scaling)
+                        # Use fused kernel for small batches to save kernel launch overhead
+                        # Fusing gate + up gives ~1.6x speedup for single token case
+                        n_tokens = len(req_indices)
+                        a_rank = A.shape[0]
+                        if cpu_kernel_mode != "naive" and n_tokens <= 2 and a_rank <= 128 and proj_lower in ("gate", "up"):
+                            with NvtxAnnotate(f"{adapter_nvtx}/Fused_{cpu_kernel_mode}_{proj_lower}_n{n_tokens}_r{a_rank}"):
+                                batch_output = moe_batch_lora_avx(batch_input, A, B, a_scaling)
+                            kernel_calls += 1
+                        else:
+                            # Stage-1: x @ A^T (naive matmul or AVX gate path)
+                            with NvtxAnnotate(f"{adapter_nvtx}/Stage1_{cpu_kernel_mode}_gate"):
+                                intermediate = gate_kernel(batch_input, A, 1.0)
+                            # Stage-2: intermediate @ B, projection-specific kernel.
+                            with NvtxAnnotate(f"{adapter_nvtx}/Stage2_{cpu_kernel_mode}_{proj_lower}"):
+                                batch_output = stage2_kernel(intermediate, B, scaling=a_scaling)
+                            kernel_calls += 2
                         output[req_indices] = batch_output
-
-                        kernel_calls += 2
                         kernel_tokens += int(len(req_indices))
                     finally:
                         if hot_handle is not None:
                             hot_handle.release()
 
+            # H2D transfer happens AFTER kernel computation (tracked separately)
             with NvtxAnnotate(f"{nvtx_root}/ReturnToOriginalDevice"):
                 if return_to_original_device and (original_device.type != "cpu" or original_dtype != torch.bfloat16):
+                    _h2d_t0 = time.perf_counter()
+                    # For naive mode: convert to bf16 on CPU first to halve H2D bandwidth
+                    if cpu_kernel_mode == "naive" and output.dtype != torch.bfloat16:
+                        output = output.to(dtype=torch.bfloat16, non_blocking=True)
                     output = output.to(device=original_device, dtype=original_dtype, non_blocking=True)
+                    if original_device.type == "cuda":
+                        torch.cuda.synchronize()
+                    self._last_colora_stats["h2d_residual_time"] += max(time.perf_counter() - _h2d_t0, 0.0)
 
             return output, kernel_calls, kernel_tokens
 
@@ -1550,6 +1599,11 @@ class Qwen3VLMoELoRADispatcher:
             "prefetch_stale": 0,
             "prefetch_false_positives": 0,
             "prefetch_slot_overwrite": 0,
+            "pack_time": 0.0,
+            "d2h_activation_time": 0.0,
+            "h2d_residual_time": 0.0,
+            "merge_time": 0.0,
+            "admit_time": 0.0,
         }
 
     def _should_use_async_cpu_fallback(self) -> bool:
@@ -2439,6 +2493,7 @@ class Qwen3VLMoELoRADispatcher:
         with NvtxAnnotate("COLoRA_MissPath_CheckAndPrepare"):
             if not state.miss_keys:
                 return
+            _pack_t0 = time.perf_counter()
             if not state.ready_slots:
                 state.miss_pos = state.valid_pos
                 state.miss_bins = state.valid_bins
@@ -2447,6 +2502,7 @@ class Qwen3VLMoELoRADispatcher:
                 state.miss_pos = state.valid_pos.index_select(0, miss_rows)
                 state.miss_bins = state.valid_bins.index_select(0, miss_rows)
             assert state.miss_pos is not None and state.miss_bins is not None
+            state.pack_time += max(time.perf_counter() - _pack_t0, 0.0)
 
             if int(state.miss_pos.numel()) == int(input_tensor.shape[0]):
                 state.miss_input = input_tensor
@@ -2462,7 +2518,9 @@ class Qwen3VLMoELoRADispatcher:
             if self._has_cpu_miss_overlap_opportunity(state, input_tensor):
                 reserve_t0 = time.perf_counter()
                 if self._reserve_async_queue_slot():
-                    state.cpu_queue_admit_wait_time += max(time.perf_counter() - reserve_t0, 0.0)
+                    _admit_elapsed = max(time.perf_counter() - reserve_t0, 0.0)
+                    state.cpu_queue_admit_wait_time += _admit_elapsed
+                    state.admit_time += _admit_elapsed
                     state.async_overlap_used = True
                     state.cpu_async_submitted += 1
                     enqueue_ts = time.perf_counter()
@@ -2497,7 +2555,12 @@ class Qwen3VLMoELoRADispatcher:
                                 adapter_group_plan=miss_plan,
                                 temporal_prefetch_context=decode_context,
                             )
-                            return miss_out, queue_wait, time.perf_counter() - t0, kernel_calls, kernel_tokens
+                            elapsed = time.perf_counter() - t0
+                            # Subtract H2D time that was tracked internally
+                            internal_h2d = self._last_colora_stats.get("h2d_residual_time", 0.0)
+                            self._last_colora_stats["h2d_residual_time"] = 0.0
+                            cpu_t = max(elapsed - internal_h2d, 0.0)
+                            return miss_out, queue_wait, cpu_t, kernel_calls, kernel_tokens, internal_h2d
                         finally:
                             self._release_async_queue_slot()
 
@@ -2676,14 +2739,19 @@ class Qwen3VLMoELoRADispatcher:
             if state.miss_future is not None:
                 with NvtxAnnotate("COLoRA_CPU_Miss_Path_AsyncJoin"):
                     join_t0 = time.perf_counter()
-                    miss_output, queue_wait, cpu_t, kernel_calls, kernel_tokens = state.miss_future.result()
+                    # Returns: miss_output, queue_wait, cpu_t, kernel_calls, kernel_tokens, internal_h2d
+                    miss_output, queue_wait, cpu_t, kernel_calls, kernel_tokens, internal_h2d = state.miss_future.result()
                     state.cpu_join_stall_time += max(time.perf_counter() - join_t0, 0.0)
+                    state.h2d_residual_time += internal_h2d
             else:
                 with NvtxAnnotate("COLoRA_CPU_Miss_Path"):
                     t0 = time.perf_counter()
                     miss_input = state.miss_input
                     if miss_input is None:
+                        _d2h_t0 = time.perf_counter()
                         miss_input = input_tensor.index_select(0, state.miss_pos).contiguous()
+                        if input_tensor.device.type == "cuda":
+                            state.d2h_activation_time += max(time.perf_counter() - _d2h_t0, 0.0)
                     miss_plan = self._build_cpu_group_plan(state.miss_bins)
                     miss_output, kernel_calls, kernel_tokens = self._strict_moe_cpu_batch_lora(
                         miss_input,
@@ -2696,10 +2764,22 @@ class Qwen3VLMoELoRADispatcher:
                     )
                     queue_wait = 0.0
                     cpu_t = time.perf_counter() - t0
+                    # H2D transfer is tracked separately in h2d_residual_time, not cpu_compute_time
+                    if miss_output.device.type == "cuda" and miss_input.device.type == "cpu":
+                        # _strict_moe_cpu_batch_lora internally did the H2D and tracked it
+                        # We need to: 1) transfer to state, 2) subtract from cpu_t
+                        internal_h2d = self._last_colora_stats.get("h2d_residual_time", 0.0)
+                        state.h2d_residual_time += internal_h2d
+                        cpu_t = max(cpu_t - internal_h2d, 0.0)
+                        self._last_colora_stats["h2d_residual_time"] = 0.0
                     state.cpu_inline_executed += 1
 
+            _merge_t0 = time.perf_counter()
             with NvtxAnnotate("COLoRA_MissPath_Writeback"):
                 state.output.index_copy_(0, state.miss_pos, miss_output)
+            if miss_output.device.type == "cuda":
+                torch.cuda.synchronize()
+            state.merge_time += max(time.perf_counter() - _merge_t0, 0.0)
             with NvtxAnnotate("COLoRA_MissPath_StatsAccumulate"):
                 state.cpu_compute_time += float(cpu_t)
                 state.cpu_queue_wait_time += float(queue_wait)
@@ -2765,6 +2845,13 @@ class Qwen3VLMoELoRADispatcher:
             "prefetch_slot_overwrite": int(
                 self._temporal_hot_cache.get_slot_overwrite_count() if self._temporal_hot_cache is not None else 0
             ),
+            # P2 microbench component timings
+            # Combine state-level and _strict_moe_cpu_batch_lora-level timings
+            "pack_time": state.pack_time,
+            "d2h_activation_time": state.d2h_activation_time + float(self._last_colora_stats.get("d2h_activation_time", 0.0)),
+            "h2d_residual_time": state.h2d_residual_time + float(self._last_colora_stats.get("h2d_residual_time", 0.0)),
+            "merge_time": state.merge_time,
+            "admit_time": state.admit_time,
         }
 
     def begin_moe_hybrid_miss_async(

--- a/test/lora/test_cold_recovery_microbench.py
+++ b/test/lora/test_cold_recovery_microbench.py
@@ -85,24 +85,6 @@ PAYLOAD_FIELDS = [
     "execution_residual_bytes", "payload_ratio",
 ]
 
-AGG_RECOVERY_EXTRA_FIELDS = [
-    "n_repeats",
-    "service_time_us_mean", "service_time_us_std",
-    "component_sum_us_mean", "component_sum_us_std",
-    "residual_us_mean", "residual_us_std",
-    "exposed_time_us_mean", "exposed_time_us_std",
-    # Component fields in alphabetical order
-    "TD2H_activation_us_mean", "TD2H_activation_us_std",
-    "TH2D_residual_us_mean", "TH2D_residual_us_std",
-    "TH2D_weights_us_mean", "TH2D_weights_us_std",
-    "Tadmit_us_mean", "Tadmit_us_std",
-    "Tcpu_us_mean", "Tcpu_us_std",
-    "Tgpu_us_mean", "Tgpu_us_std",
-    "Tmerge_us_mean", "Tmerge_us_std",
-    "Tpack_us_mean", "Tpack_us_std",
-]
-
-
 def test_recovery_csv_fieldnames_match(runner_module):
     """Verify the RECOVERY_FIELDS constant in the runner matches the contract."""
     assert runner_module.RECOVERY_FIELDS == RECOVERY_FIELDS
@@ -185,10 +167,8 @@ def test_plot_script_exists():
     assert PLOT_SCRIPT_PATH.exists(), f"plot script not found at {PLOT_SCRIPT_PATH}"
 
 
-def test_aggregated_csv_field_contract():
-    """Verify the aggregation function produces expected fields."""
-    import sys
-    mod = _load_runner_module()
+def test_aggregated_csv_field_contract(runner_module):
+    """Verify _aggregate_repeats matches AGG_FIELDS (median + MAD per numeric column)."""
     sample_rows = [
         {
             "policy": "cpu_first", "lora_rank": 16, "batch_size": 4,
@@ -207,16 +187,16 @@ def test_aggregated_csv_field_contract():
             "exposed_time_us": 0.0,
         },
     ]
-    agg = mod._aggregate_repeats(sample_rows)
+    agg = runner_module._aggregate_repeats(sample_rows)
     assert len(agg) == 1
     row = agg[0]
     assert row["policy"] == "cpu_first"
     assert row["lora_rank"] == 16
     assert row["batch_size"] == 4
     assert row["n_repeats"] == 2
-    assert "service_time_us_mean" in row
-    assert "service_time_us_std" in row
-    for field in AGG_RECOVERY_EXTRA_FIELDS:
+    assert "service_time_us_median" in row
+    assert "service_time_us_mad" in row
+    for field in runner_module.AGG_FIELDS:
         assert field in row, f"aggregated row missing field: {field}"
 
 

--- a/test/lora/test_cold_recovery_microbench.py
+++ b/test/lora/test_cold_recovery_microbench.py
@@ -1,0 +1,269 @@
+"""Tests for the P2 cold miss recovery microbenchmark pipeline.
+
+Validates:
+  - MicrobenchConfig YAML parsing
+  - CSV column contract for recovery and payload artifacts
+  - Component timing schema (all required fields present in dispatcher stats)
+  - Plotting script CSV reader contract
+"""
+
+import csv
+import importlib.util
+import tempfile
+from pathlib import Path
+from typing import Dict, List
+
+import pytest
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+MICROBENCH_CONFIG_PATH = REPO_ROOT / "configs/evaluation/colora_kpi/microbench_config.yaml"
+MICROBENCH_RUNNER_PATH = REPO_ROOT / "tools/evaluation/colora_microbench_cold_recovery.py"
+PLOT_SCRIPT_PATH = REPO_ROOT / "tools/evaluation/plot_cold_recovery_microbench.py"
+DISPATCHER_PATH = REPO_ROOT / "lightllm/models/qwen3_vl_moe/lora_dispatch.py"
+
+
+# ---------------------------------------------------------------------------
+# MicrobenchConfig parsing
+# ---------------------------------------------------------------------------
+
+def _load_runner_module():
+    import sys
+    spec = importlib.util.spec_from_file_location("colora_microbench_cold_recovery", MICROBENCH_RUNNER_PATH)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["colora_microbench_cold_recovery"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def runner_module():
+    return _load_runner_module()
+
+
+def test_microbench_config_yaml_exists():
+    assert MICROBENCH_CONFIG_PATH.exists(), f"microbench_config.yaml not found at {MICROBENCH_CONFIG_PATH}"
+
+
+def test_microbench_config_parses(runner_module):
+    config = runner_module.MicrobenchConfig.from_yaml(MICROBENCH_CONFIG_PATH)
+    assert config.hidden_size > 0
+    assert config.dtype in ("fp16", "bf16")
+    assert len(config.ranks) >= 2, "should have at least 2 rank values"
+    assert len(config.batch_sizes) >= 2, "should have at least 2 batch size values"
+    assert config.repeats >= 1
+    assert config.output_dir
+
+
+def test_microbench_config_defaults(runner_module):
+    config = runner_module.MicrobenchConfig()
+    assert config.ranks == [8, 16, 32, 64]
+    assert config.batch_sizes == [1, 2, 4, 8]
+    assert config.repeats == 3
+    assert config.dtype == "fp16"
+
+
+# ---------------------------------------------------------------------------
+# CSV column contracts
+# ---------------------------------------------------------------------------
+
+RECOVERY_FIELDS = [
+    "policy", "lora_rank", "batch_size", "repeat_idx",
+    "service_time_us", "component_sum_us", "residual_us",
+    # ALL_COMPONENTS in alphabetical order (matches runner's sorted(set(...)))
+    "TD2H_activation_us", "TH2D_residual_us", "TH2D_weights_us",
+    "Tadmit_us", "Tcpu_us", "Tgpu_us", "Tmerge_us", "Tpack_us",
+    "exposed_time_us",
+]
+
+PAYLOAD_FIELDS = [
+    "policy", "lora_rank", "batch_size",
+    "promotion_weight_bytes", "execution_activation_bytes",
+    "execution_residual_bytes", "payload_ratio",
+]
+
+AGG_RECOVERY_EXTRA_FIELDS = [
+    "n_repeats",
+    "service_time_us_mean", "service_time_us_std",
+    "component_sum_us_mean", "component_sum_us_std",
+    "residual_us_mean", "residual_us_std",
+    "exposed_time_us_mean", "exposed_time_us_std",
+    # Component fields in alphabetical order
+    "TD2H_activation_us_mean", "TD2H_activation_us_std",
+    "TH2D_residual_us_mean", "TH2D_residual_us_std",
+    "TH2D_weights_us_mean", "TH2D_weights_us_std",
+    "Tadmit_us_mean", "Tadmit_us_std",
+    "Tcpu_us_mean", "Tcpu_us_std",
+    "Tgpu_us_mean", "Tgpu_us_std",
+    "Tmerge_us_mean", "Tmerge_us_std",
+    "Tpack_us_mean", "Tpack_us_std",
+]
+
+
+def test_recovery_csv_fieldnames_match(runner_module):
+    """Verify the RECOVERY_FIELDS constant in the runner matches the contract."""
+    assert runner_module.RECOVERY_FIELDS == RECOVERY_FIELDS
+
+
+def test_payload_csv_fieldnames_match(runner_module):
+    """Verify the PAYLOAD_FIELDS constant in the runner matches the contract."""
+    assert runner_module.PAYLOAD_FIELDS == PAYLOAD_FIELDS
+
+
+def test_csv_writer_produces_correct_columns(runner_module):
+    """Verify CSV writers produce the correct column headers."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        recovery_path = Path(tmpdir) / "microbench_cold_recovery.csv"
+        payload_path = Path(tmpdir) / "microbench_payload_size.csv"
+
+        sample_recovery = [{
+            "policy": "cpu_first", "lora_rank": 16, "batch_size": 4,
+            "repeat_idx": 1, "service_time_us": 100.0, "component_sum_us": 100.0,
+            "residual_us": 0.0, "TD2H_activation_us": 20.0, "TH2D_residual_us": 20.0,
+            "TH2D_weights_us": 0.0, "Tadmit_us": 0.0, "Tcpu_us": 50.0,
+            "Tgpu_us": 0.0, "Tmerge_us": 5.0, "Tpack_us": 5.0,
+            "exposed_time_us": 0.0,
+        }]
+        sample_payload = [{
+            "policy": "cpu_first", "lora_rank": 16, "batch_size": 4,
+            "promotion_weight_bytes": 262144.0, "execution_activation_bytes": 32768.0,
+            "execution_residual_bytes": 32768.0, "payload_ratio": 4.0,
+        }]
+
+        runner_module._write_recovery_csv(recovery_path, sample_recovery)
+        runner_module._write_payload_csv(payload_path, sample_payload)
+
+        with recovery_path.open("r", newline="") as f:
+            reader = csv.DictReader(f)
+            assert reader.fieldnames == RECOVERY_FIELDS
+            rows = list(reader)
+            assert len(rows) == 1
+            assert rows[0]["policy"] == "cpu_first"
+
+        with payload_path.open("r", newline="") as f:
+            reader = csv.DictReader(f)
+            assert reader.fieldnames == PAYLOAD_FIELDS
+            rows = list(reader)
+            assert len(rows) == 1
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher component timing fields
+# ---------------------------------------------------------------------------
+
+DISPATCHER_P2_FIELDS = [
+    "pack_time",
+    "d2h_activation_time",
+    "h2d_residual_time",
+    "merge_time",
+    "admit_time",
+]
+
+
+def test_dispatcher_has_p2_timing_fields():
+    """Verify the dispatcher stats dict includes P2 component timing fields."""
+    dispatcher_src = DISPATCHER_PATH.read_text(encoding="utf-8")
+    for field in DISPATCHER_P2_FIELDS:
+        assert f'"{field}"' in dispatcher_src, f"dispatcher missing P2 field: {field}"
+
+
+def test_dispatcher_state_has_p2_fields():
+    """Verify _MoEHybridPhaseState dataclass includes P2 timing fields."""
+    dispatcher_src = DISPATCHER_PATH.read_text(encoding="utf-8")
+    for field in DISPATCHER_P2_FIELDS:
+        assert f"{field}: float" in dispatcher_src, f"_MoEHybridPhaseState missing: {field}: float"
+
+
+# ---------------------------------------------------------------------------
+# Plotting contract
+# ---------------------------------------------------------------------------
+
+def test_plot_script_exists():
+    assert PLOT_SCRIPT_PATH.exists(), f"plot script not found at {PLOT_SCRIPT_PATH}"
+
+
+def test_aggregated_csv_field_contract():
+    """Verify the aggregation function produces expected fields."""
+    import sys
+    mod = _load_runner_module()
+    sample_rows = [
+        {
+            "policy": "cpu_first", "lora_rank": 16, "batch_size": 4,
+            "repeat_idx": 1, "service_time_us": 100.0, "component_sum_us": 100.0,
+            "residual_us": 0.0, "Tpack_us": 5.0, "TD2H_activation_us": 20.0,
+            "Tcpu_us": 50.0, "TH2D_residual_us": 20.0, "Tmerge_us": 5.0,
+            "Tadmit_us": 0.0, "TH2D_weights_us": 0.0, "Tgpu_us": 0.0,
+            "exposed_time_us": 0.0,
+        },
+        {
+            "policy": "cpu_first", "lora_rank": 16, "batch_size": 4,
+            "repeat_idx": 2, "service_time_us": 110.0, "component_sum_us": 110.0,
+            "residual_us": 0.0, "Tpack_us": 6.0, "TD2H_activation_us": 22.0,
+            "Tcpu_us": 52.0, "TH2D_residual_us": 22.0, "Tmerge_us": 6.0,
+            "Tadmit_us": 0.0, "TH2D_weights_us": 0.0, "Tgpu_us": 0.0,
+            "exposed_time_us": 0.0,
+        },
+    ]
+    agg = mod._aggregate_repeats(sample_rows)
+    assert len(agg) == 1
+    row = agg[0]
+    assert row["policy"] == "cpu_first"
+    assert row["lora_rank"] == 16
+    assert row["batch_size"] == 4
+    assert row["n_repeats"] == 2
+    assert "service_time_us_mean" in row
+    assert "service_time_us_std" in row
+    for field in AGG_RECOVERY_EXTRA_FIELDS:
+        assert field in row, f"aggregated row missing field: {field}"
+
+
+# ---------------------------------------------------------------------------
+# Component additivity check
+# ---------------------------------------------------------------------------
+
+def test_component_additivity_for_execution_first():
+    """Verify execution-first component sum equals service time for synthetic data."""
+    mod = _load_runner_module()
+    stats = {
+        "cpu_compute_time": 0.000100,  # 100 us
+        "gpu_compute_time": 0.0,
+        "weight_h2d_time": 0.0,
+        "pack_time": 0.000005,
+        "d2h_activation_time": 0.000020,
+        "h2d_residual_time": 0.000020,
+        "merge_time": 0.000005,
+        "admit_time": 0.000010,
+    }
+    rows = mod._extract_component_timings([stats], "cpu_first")
+    assert len(rows) == 1
+    row = rows[0]
+    # service_time should equal sum of components
+    expected_sum = row["Tpack_us"] + row["TD2H_activation_us"] + row["Tcpu_us"] + row["TH2D_residual_us"] + row["Tmerge_us"] + row["Tadmit_us"]
+    assert abs(row["service_time_us"] - expected_sum) < 0.01, \
+        f"service_time={row['service_time_us']} != component_sum={expected_sum}"
+    assert row["residual_us"] < 0.01
+
+
+def test_component_additivity_for_promotion_first():
+    """Verify promotion-first component sum equals service time for synthetic data."""
+    mod = _load_runner_module()
+    stats = {
+        "cpu_compute_time": 0.0,
+        "gpu_compute_time": 0.000200,
+        "weight_h2d_time": 0.000300,
+        "pack_time": 0.0,
+        "d2h_activation_time": 0.0,
+        "h2d_residual_time": 0.0,
+        "merge_time": 0.000010,
+        "admit_time": 0.000050,
+    }
+    rows = mod._extract_component_timings([stats], "load_then_run")
+    assert len(rows) == 1
+    row = rows[0]
+    expected_sum = row["Tadmit_us"] + row["TH2D_weights_us"] + row["Tgpu_us"] + row["Tmerge_us"]
+    assert abs(row["service_time_us"] - expected_sum) < 0.01, \
+        f"service_time={row['service_time_us']} != component_sum={expected_sum}"
+    assert row["residual_us"] < 0.01

--- a/test_kernel_benchmark.py
+++ b/test_kernel_benchmark.py
@@ -1,0 +1,68 @@
+import torch
+torch.set_num_threads(1)
+import time
+
+print('=' * 60)
+print('KERNEL-ONLY BENCHMARK (no D2H/H2D overhead)')
+print('=' * 60)
+
+H = 4096
+R = 8
+N = 1
+scaling = 1.0
+
+x = torch.randn(N, H, dtype=torch.bfloat16)
+A = torch.randn(R, H, dtype=torch.bfloat16)
+B = torch.randn(R, H, dtype=torch.bfloat16)
+inter = torch.randn(N, R, dtype=torch.bfloat16)
+
+from lightllm._kernels.lora.moe_lora_cpu_kernel import (
+    moe_batch_lora_gate_avx, 
+    moe_batch_lora_up_avx,
+)
+
+iters = 2000
+
+# PyTorch reference
+t0 = time.perf_counter()
+for _ in range(iters):
+    _ = x @ A.T
+torch_gate = (time.perf_counter() - t0) / iters * 1e6
+
+t0 = time.perf_counter()
+for _ in range(iters):
+    _ = inter @ B
+torch_up = (time.perf_counter() - t0) / iters * 1e6
+
+# AVX kernels
+for _ in range(100): _ = moe_batch_lora_gate_avx(x, A, 1.0)
+t0 = time.perf_counter()
+for _ in range(iters):
+    _ = moe_batch_lora_gate_avx(x, A, 1.0)
+avx_gate = (time.perf_counter() - t0) / iters * 1e6
+
+for _ in range(100): _ = moe_batch_lora_up_avx(inter, B, scaling)
+t0 = time.perf_counter()
+for _ in range(iters):
+    _ = moe_batch_lora_up_avx(inter, B, scaling)
+avx_up = (time.perf_counter() - t0) / iters * 1e6
+
+print("{:<25} {:>10} {:>10} {:>10}".format("Kernel", "PyTorch", "AVX-512", "Speedup"))
+print('-' * 60)
+print("{:<25} {:>9.1f}us {:>9.1f}us {:>9.1f}x".format(
+    "Gate (x@A^T)", torch_gate, avx_gate, torch_gate/avx_gate))
+print("{:<25} {:>9.1f}us {:>9.1f}us {:>9.1f}x".format(
+    "Up (inter@B)", torch_up, avx_up, torch_up/avx_up))
+print()
+print("{:<25} {:>9.1f}us {:>9.1f}us {:>9.1f}x".format(
+    "Total Gate + Up", torch_gate + torch_up, avx_gate + avx_up, 
+    (torch_gate + torch_up)/(avx_gate + avx_up)))
+print()
+print('=' * 60)
+print('BOTTLENECK ANALYSIS')
+print('=' * 60)
+print(f'AVX Gate kernel H={H}: {avx_gate:.1f} us / {1/(avx_gate*1e-6)/1e6:.1f} M ops/sec')
+print(f'AVX Up kernel H={H}: {avx_up:.1f} us / {1/(avx_up*1e-6)/1e6:.1f} M ops/sec')
+print(f'Theoretical peak (3GHz, 32 ops/cycle): 65.5 us for 2*8*4096 ops')
+print(f'Gate efficiency: {65.5/(2*avx_gate):.1%} (only half of work)')
+print(f'Up efficiency: {65.5/(2*avx_up):.1%}')

--- a/tools/evaluation/colora_microbench_cold_recovery.py
+++ b/tools/evaluation/colora_microbench_cold_recovery.py
@@ -1,0 +1,969 @@
+#!/usr/bin/env python3
+"""P2 Cold Miss Recovery Microbenchmark.
+
+Isolates one-layer MoE expert-LoRA decode cold-miss recovery and compares
+load_then_run (promotion-first) vs cpu_first (execution-first) with
+component-level latency decomposition and payload-size accounting.
+
+Produces:
+  - microbench_cold_recovery.csv
+  - microbench_payload_size.csv
+"""
+
+import os
+
+# Set triton cache dir before any other imports
+os.environ.setdefault("TRITON_CACHE_DIR", "/tmp/triton_cache")
+
+# Force naive CPU kernel mode and availability flag for systems without AVX-512 BF16
+os.environ.setdefault("COLORA_CPU_KERNEL_MODE", "naive")
+import lightllm.models.qwen3_vl_moe.lora_dispatch as lora_dispatch_module
+lora_dispatch_module.MOE_AVX_AVAILABLE = True
+
+import argparse
+import csv
+import math
+import statistics
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence
+
+import torch
+import yaml
+
+
+# ---------------------------------------------------------------------------
+# Schema: component latency names per strategy
+# ---------------------------------------------------------------------------
+
+EXECUTION_FIRST_COMPONENTS = [
+    "Tpack_us",
+    "TD2H_activation_us",
+    "Tcpu_us",
+    "TH2D_residual_us",
+    "Tmerge_us",
+]
+
+PROMOTION_FIRST_COMPONENTS = [
+    "Tadmit_us",
+    "TH2D_weights_us",
+    "Tgpu_us",
+]
+
+ALL_COMPONENTS = sorted(set(EXECUTION_FIRST_COMPONENTS + PROMOTION_FIRST_COMPONENTS))
+
+# Maps from dispatcher stats -> P2 component names (filled at runtime after
+# we measure the actual path).  The sweep runner builds these mappings from
+# the fine-grained NVTX phases and dispatcher counters.
+
+_EXECUTION_FIRST_MAP = {
+    "Tpack_us": "pack_time_us",
+    "TD2H_activation_us": "d2h_activation_time_us",
+    "Tcpu_us": "cpu_compute_time_us",
+    "TH2D_residual_us": "h2d_residual_time_us",
+    "Tmerge_us": "merge_time_us",
+}
+
+_PROMOTION_FIRST_MAP = {
+    "Tadmit_us": "admit_time_us",
+    "TH2D_weights_us": "weight_h2d_time_us",
+    "Tgpu_us": "gpu_compute_time_us",
+}
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+@dataclass
+class MicrobenchConfig:
+    hidden_size: int = 4096
+    intermediate_size: int = 14336
+    num_experts: int = 64
+    topk: int = 8
+    ranks: List[int] = field(default_factory=lambda: [8, 16, 32, 64])
+    batch_sizes: List[int] = field(default_factory=lambda: [1, 2, 4, 8])
+    dtype: str = "fp16"
+    projection: str = "gate"
+    repeats: int = 3
+    warmup_iters: int = 10
+    measurement_iters: int = 100
+    cache_budget_mb: int = 64
+    cpu_threads: int = 1
+    cpu_kernel_mode: str = "avx"
+    numa_node: Optional[int] = None
+    promote_min_hits: int = 1
+    promote_window: int = 16
+    max_promote_per_step: int = 8
+    decay: float = 0.9
+    output_dir: str = "results/microbench_cold_recovery"
+
+    @classmethod
+    def from_yaml(cls, path: Path) -> "MicrobenchConfig":
+        payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+        if not isinstance(payload, dict):
+            raise ValueError(f"expected mapping in YAML file: {path}")
+        known = {f.name for f in cls.__dataclass_fields__.values()}
+        filtered = {k: v for k, v in payload.items() if k in known}
+        return cls(**filtered)
+
+
+# ---------------------------------------------------------------------------
+# Result rows
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ColdRecoveryRow:
+    policy: str
+    lora_rank: int
+    batch_size: int
+    repeat_idx: int
+    service_time_us: float
+    component_sum_us: float
+    residual_us: float
+    Tpack_us: float = 0.0
+    TD2H_activation_us: float = 0.0
+    Tcpu_us: float = 0.0
+    TH2D_residual_us: float = 0.0
+    Tmerge_us: float = 0.0
+    Tadmit_us: float = 0.0
+    TH2D_weights_us: float = 0.0
+    Tgpu_us: float = 0.0
+
+
+@dataclass
+class PayloadSizeRow:
+    policy: str
+    lora_rank: int
+    batch_size: int
+    promotion_weight_bytes: float
+    execution_activation_bytes: float
+    execution_residual_bytes: float
+    payload_ratio: float  # weight_bytes / (activation_bytes + residual_bytes)
+
+
+# ---------------------------------------------------------------------------
+# One-layer benchmark driver (component-level)
+# ---------------------------------------------------------------------------
+
+def _dtype_from_name(name: str) -> torch.dtype:
+    if name == "fp16":
+        return torch.float16
+    if name == "bf16":
+        return torch.bfloat16
+    raise ValueError(f"unsupported dtype: {name}")
+
+
+def _run_cold_miss_single(
+    *,
+    policy: str,
+    lora_rank: int,
+    batch_size: int,
+    hidden_size: int,
+    num_experts: int,
+    topk: int,
+    projection: str,
+    dtype: torch.dtype,
+    cache_budget_mb: int,
+    warmup_iters: int,
+    measurement_iters: int,
+    promote_min_hits: int,
+    promote_window: int,
+    max_promote_per_step: int,
+    decay: float,
+) -> Dict[str, Any]:
+    """Run the one-layer cold-miss benchmark for a single (policy, rank, batch).
+
+    Returns a dict with per-iteration component timings and payload sizes.
+    """
+    from lightllm.models.qwen3_vl_moe.lora_dispatch import (
+        BGMV_AVAILABLE,
+        Qwen3VLMoELoRADispatcher,
+    )
+    from lightllm.server.core.objs.lora_compute_config import LoRAComputeConfig
+    from lightllm.server.lora.expert_cache import (
+        ExpertCacheKey,
+        ExpertCacheSlotState,
+        MoEExpertCacheConfig,
+        MoEExpertCacheManager,
+    )
+    from lightllm.server.lora.lora_mem_pool import LoRAModulePool
+
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    if not BGMV_AVAILABLE:
+        raise RuntimeError("BGMV kernel is required")
+
+    device = torch.device("cuda")
+    layer_id = 0
+    expert_id = 0
+    hit_adapter_id = 0
+
+    pool = LoRAModulePool.create(
+        pool_size=32,
+        max_rank=lora_rank,
+        input_dim=hidden_size,
+        output_dim=hidden_size,
+        dtype=dtype,
+        device="cpu",
+        num_layers=1,
+        num_experts=1,
+    )
+
+    # Load hit adapter (always in cache for GPU path)
+    lora_a = torch.randn(lora_rank, hidden_size, dtype=dtype)
+    lora_b = torch.randn(lora_rank, hidden_size, dtype=dtype)
+    ok = pool.load_adapter(
+        adapter_idx=hit_adapter_id,
+        rank=lora_rank,
+        scaling=1.0,
+        layer_weights={0: {"A": lora_a, "B": lora_b}},
+    )
+    if not ok:
+        raise RuntimeError(f"failed to load hit adapter {hit_adapter_id}")
+
+    # Load miss adapters: 1..batch_size (one per token for diversified cold miss)
+    # Each token maps to a DIFFERENT adapter for realistic MoE routing
+    miss_adapter_ids = list(range(1, 1 + batch_size))
+    for adapter_idx in miss_adapter_ids:
+        lora_a = torch.randn(lora_rank, hidden_size, dtype=dtype)
+        lora_b = torch.randn(lora_rank, hidden_size, dtype=dtype)
+        ok = pool.load_adapter(
+            adapter_idx=adapter_idx,
+            rank=lora_rank,
+            scaling=1.0,
+            layer_weights={0: {"A": lora_a, "B": lora_b}},
+        )
+        if not ok:
+            raise RuntimeError(f"failed to load adapter {adapter_idx}")
+
+    cache_mgr = MoEExpertCacheManager(
+        MoEExpertCacheConfig(
+            cache_budget_mb=cache_budget_mb,
+            promote_min_hits=promote_min_hits,
+            promote_window=promote_window,
+            # For load_then_run: set max_promote_per_step to 0 to disable
+            # async apply_completed_promotions, forcing all promotion to
+            # happen synchronously in promote_blocking where timing is tracked
+            max_promote_per_step=0 if policy == "load_then_run" else max_promote_per_step,
+            decay=decay,
+            miss_policy=policy,
+        )
+    )
+    cache_mgr.register_projection_pool(projection, pool)
+
+    # Pre-promote hit adapter so only miss_adapter is cold
+    hit_key = ExpertCacheKey(
+        projection=projection,
+        adapter_idx=hit_adapter_id,
+        layer_id=layer_id,
+        expert_id=expert_id,
+    )
+    cache_mgr.record_access([hit_key])
+    cache_mgr.schedule_promotion([hit_key])
+    cache_mgr.apply_completed_promotions()
+
+    rank_kwargs = {"gate_lora_rank": 0, "up_lora_rank": 0, "down_lora_rank": 0}
+    rank_kwargs[f"{projection}_lora_rank"] = lora_rank
+    dispatcher = Qwen3VLMoELoRADispatcher(
+        num_layers=1,
+        lora_compute_config=LoRAComputeConfig(moe_storage="cpu", moe_compute="hybrid"),
+        **rank_kwargs,
+    )
+    dispatcher.expert_cache_manager = cache_mgr
+
+    x = torch.randn(batch_size, hidden_size, dtype=dtype, device=device)
+    # Each token maps to a DIFFERENT miss adapter (diversified cold miss)
+    # Adapter 0 = hit (pre-promoted), Adapters 1..batch_size = cold
+    bins = torch.tensor(miss_adapter_ids, dtype=torch.long, device=device)
+
+    # Create cache keys for all miss adapters
+    miss_keys = [
+        ExpertCacheKey(
+            projection=projection,
+            adapter_idx=adapter_idx,
+            layer_id=layer_id,
+            expert_id=expert_id,
+        )
+        for adapter_idx in miss_adapter_ids
+    ]
+
+    def _evict_miss_adapters() -> None:
+        """Evict all miss adapters from cache so next iteration starts cold."""
+        # First, ensure any async promotions are complete
+        cache_mgr.apply_completed_promotions()
+        # Evict by directly removing from cache manager entries
+        if hasattr(cache_mgr, "_states"):
+            state = cache_mgr._states.get(projection)
+            if state:
+                for miss_key in miss_keys:
+                    if miss_key in state.entries:
+                        entry = state.entries[miss_key]
+                        slot_id = entry.slot_id
+                        # Mark entry as INVALID before removal
+                        entry.state = ExpertCacheSlotState.INVALID
+                        entry.slot_id = -1
+                        del state.entries[miss_key]
+                        if slot_id >= 0:
+                            state.slot_to_key.pop(slot_id, None)
+                            # Return slot to free list
+                            if slot_id not in state.free_slots:
+                                state.free_slots.append(slot_id)
+                        # Remove from queued set if present
+                        state.queued.discard(miss_key)
+
+    def _run_once_cpu_first():
+        """cpu_first: suppress promotion to measure pure CPU execution path."""
+        original_record = cache_mgr.record_access
+        original_schedule = cache_mgr.schedule_promotion
+        try:
+            cache_mgr.record_access = lambda keys: None
+            cache_mgr.schedule_promotion = lambda keys: None
+            lora_out = dispatcher._batch_apply_moe_lora_hybrid(
+                input_tensor=x,
+                layer_id=layer_id,
+                buffer_layer_id=layer_id,
+                pool=pool,
+                bins=bins,
+                projection=projection,
+                expert_id=expert_id,
+            )
+        finally:
+            cache_mgr.record_access = original_record
+            cache_mgr.schedule_promotion = original_schedule
+        if lora_out.device.type == "cuda":
+            torch.cuda.synchronize()
+        return dispatcher.pop_colora_stats()
+
+    def _run_once_load_then_run():
+        """load_then_run: allow promotion to measure real H2D weight transfer + GPU compute."""
+        # Ensure miss adapters are evicted before each run to guarantee cold start
+        _evict_miss_adapters()
+        # Record access TWICE to ensure access_count >= promote_min_hits
+        # (required for schedule_promotion to actually queue the keys)
+        cache_mgr.record_access(miss_keys)
+        cache_mgr.record_access(miss_keys)
+        # Run with promotion enabled
+        lora_out = dispatcher._batch_apply_moe_lora_hybrid(
+            input_tensor=x,
+            layer_id=layer_id,
+            buffer_layer_id=layer_id,
+            pool=pool,
+            bins=bins,
+            projection=projection,
+            expert_id=expert_id,
+        )
+        if lora_out.device.type == "cuda":
+            torch.cuda.synchronize()
+        return dispatcher.pop_colora_stats()
+
+    _run_once = _run_once_cpu_first if policy == "cpu_first" else _run_once_load_then_run
+
+    # Warmup Strategy: compile kernels BUT KEEP miss_adapters COLD
+    if policy == "cpu_first":
+        # For cpu_first: warm up CPU path directly
+        for _ in range(warmup_iters):
+            _run_once_cpu_first()
+    else:
+        # For load_then_run: warmup GPU kernels WITHOUT warming miss adapters
+        # Use hit_adapter to warm up kernels
+        warmup_bins = torch.tensor([0] * batch_size, dtype=torch.long, device=device)
+        for _ in range(max(warmup_iters, 3)):
+            _ = dispatcher._batch_apply_moe_lora_hybrid(
+                input_tensor=x, layer_id=layer_id, buffer_layer_id=layer_id,
+                pool=pool, bins=warmup_bins, projection=projection, expert_id=expert_id)
+        torch.cuda.synchronize()
+
+    # Measurement: collect per-iteration stats
+    per_iter_stats: List[Dict[str, Any]] = []
+    for _ in range(measurement_iters):
+        stats = _run_once()
+        per_iter_stats.append(stats)
+
+    # Compute payload sizes from first iteration
+    sample_stats = per_iter_stats[0]
+
+    # Full expert-LoRA weight bytes: 2 * rank * hidden_size * element_size
+    element_bytes = x.element_size()
+    full_weight_bytes = 2.0 * lora_rank * hidden_size * element_bytes
+
+    # Activation bytes: batch_size * hidden_size * element_size
+    activation_bytes = float(batch_size) * hidden_size * element_bytes
+
+    # Residual bytes: same as activation bytes (LoRA residual = same shape)
+    residual_bytes = activation_bytes
+
+    # Extract component timings from dispatcher stats
+    # We compute from the already-accumulated per-iter counters
+    n_iters = len(per_iter_stats)
+
+    results: Dict[str, Any] = {
+        "policy": policy,
+        "lora_rank": lora_rank,
+        "batch_size": batch_size,
+        "per_iter_stats": per_iter_stats,
+        "payload": {
+            "promotion_weight_bytes": full_weight_bytes,
+            "execution_activation_bytes": activation_bytes,
+            "execution_residual_bytes": residual_bytes,
+        },
+    }
+    return results
+
+
+def _extract_component_timings(
+    per_iter_stats: List[Dict[str, Any]],
+    policy: str,
+) -> List[Dict[str, float]]:
+    """Convert per-iteration dispatcher stats to P2 component timings.
+
+    Mapping from dispatcher counters to P2 decomposition:
+      Execution-first:
+        Tpack    = pack_time (gather/index_select of miss tokens)
+        TD2H     = d2h_activation_time (activation D2H transfer)
+        Tcpu     = cpu_compute_time - d2h_activation_time - h2d_residual_time
+        TH2D     = h2d_residual_time (residual H2D transfer)
+        Tmerge   = merge_time (index_copy_ writeback)
+
+      Promotion-first:
+        Tadmit   = admit_time (cache admission)
+        TH2D_w   = weight_h2d_time (full weight H2D transfer)
+        Tgpu     = gpu_compute_time (GPU LoRA residual compute)
+    """
+    rows: List[Dict[str, float]] = []
+    for stats in per_iter_stats:
+        cpu_compute_s = float(stats.get("cpu_compute_time", 0.0))
+        gpu_compute_s = float(stats.get("gpu_compute_time", 0.0))
+        weight_h2d_s = float(stats.get("weight_h2d_time", 0.0))
+        pack_s = float(stats.get("pack_time", 0.0))
+        d2h_act_s = float(stats.get("d2h_activation_time", 0.0))
+        h2d_res_s = float(stats.get("h2d_residual_time", 0.0))
+        merge_s = float(stats.get("merge_time", 0.0))
+        admit_s = float(stats.get("admit_time", 0.0))
+
+        if policy == "cpu_first":
+            pure_cpu_s = max(cpu_compute_s - d2h_act_s - h2d_res_s, 0.0)
+            service_time_us = (pack_s + d2h_act_s + pure_cpu_s + h2d_res_s + merge_s + admit_s) * 1e6
+            component_sum_us = service_time_us  # direct sum, no estimation
+
+            row = {
+                "service_time_us": service_time_us,
+                "component_sum_us": component_sum_us,
+                "residual_us": abs(service_time_us - component_sum_us),
+                "Tpack_us": pack_s * 1e6,
+                "TD2H_activation_us": d2h_act_s * 1e6,
+                "Tcpu_us": pure_cpu_s * 1e6,
+                "TH2D_residual_us": h2d_res_s * 1e6,
+                "Tmerge_us": merge_s * 1e6,
+                "Tadmit_us": admit_s * 1e6,
+                "TH2D_weights_us": 0.0,
+                "Tgpu_us": 0.0,
+            }
+        elif policy == "load_then_run":
+            service_time_us = (admit_s + weight_h2d_s + gpu_compute_s + merge_s) * 1e6
+            component_sum_us = service_time_us
+
+            row = {
+                "service_time_us": service_time_us,
+                "component_sum_us": component_sum_us,
+                "residual_us": abs(service_time_us - component_sum_us),
+                "Tpack_us": 0.0,
+                "TD2H_activation_us": 0.0,
+                "Tcpu_us": 0.0,
+                "TH2D_residual_us": 0.0,
+                "Tmerge_us": merge_s * 1e6,
+                "Tadmit_us": admit_s * 1e6,
+                "TH2D_weights_us": weight_h2d_s * 1e6,
+                "Tgpu_us": gpu_compute_s * 1e6,
+            }
+        else:
+            raise ValueError(f"unknown policy: {policy}")
+
+        rows.append(row)
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Optional: overlap / exposed-time benchmark
+# ---------------------------------------------------------------------------
+
+def _run_overlap_benchmark(
+    *,
+    policy: str,
+    lora_rank: int,
+    batch_size: int,
+    hidden_size: int,
+    num_experts: int,
+    topk: int,
+    projection: str,
+    dtype: torch.dtype,
+    cache_budget_mb: int,
+    warmup_iters: int,
+    measurement_iters: int,
+    promote_min_hits: int,
+    promote_window: int,
+    max_promote_per_step: int,
+    decay: float,
+    dummy_gpu_iters: int = 10,
+) -> float:
+    """Run the cold-miss benchmark with concurrent dummy GPU work.
+
+    Measures the exposed stall time: how long the decode stream is
+    actually blocked when the CPU cold path runs in parallel with
+    dummy base/hot GPU computation.
+
+    Returns median exposed_time_us across measurement iterations.
+    """
+    from lightllm.models.qwen3_vl_moe.lora_dispatch import (
+        BGMV_AVAILABLE,
+        Qwen3VLMoELoRADispatcher,
+    )
+    from lightllm.server.core.objs.lora_compute_config import LoRAComputeConfig
+    from lightllm.server.lora.expert_cache import (
+        ExpertCacheKey,
+        MoEExpertCacheConfig,
+        MoEExpertCacheManager,
+    )
+    from lightllm.server.lora.lora_mem_pool import LoRAModulePool
+
+    if not torch.cuda.is_available() or not BGMV_AVAILABLE:
+        return 0.0
+
+    device = torch.device("cuda")
+    layer_id = 0
+    expert_id = 0
+    hit_adapter_id = 0
+    miss_adapter_id = 1
+
+    pool = LoRAModulePool.create(
+        pool_size=32, max_rank=lora_rank, input_dim=hidden_size,
+        output_dim=hidden_size, dtype=dtype, device="cpu",
+        num_layers=1, num_experts=1,
+    )
+    for adapter_idx in (hit_adapter_id, miss_adapter_id):
+        lora_a = torch.randn(lora_rank, hidden_size, dtype=dtype)
+        lora_b = torch.randn(lora_rank, hidden_size, dtype=dtype)
+        pool.load_adapter(
+            adapter_idx=adapter_idx, rank=lora_rank, scaling=1.0,
+            layer_weights={0: {"A": lora_a, "B": lora_b}},
+        )
+
+    cache_mgr = MoEExpertCacheManager(
+        MoEExpertCacheConfig(
+            cache_budget_mb=cache_budget_mb, promote_min_hits=promote_min_hits,
+            promote_window=promote_window,
+            # For load_then_run: set max_promote_per_step to 0 to disable
+            # async apply_completed_promotions, forcing all promotion to
+            # happen synchronously in promote_blocking where timing is tracked
+            max_promote_per_step=0 if policy == "load_then_run" else max_promote_per_step,
+            decay=decay, miss_policy=policy,
+        )
+    )
+    cache_mgr.register_projection_pool(projection, pool)
+
+    hit_key = ExpertCacheKey(
+        projection=projection, adapter_idx=hit_adapter_id,
+        layer_id=layer_id, expert_id=expert_id,
+    )
+    cache_mgr.record_access([hit_key])
+    cache_mgr.schedule_promotion([hit_key])
+    cache_mgr.apply_completed_promotions()
+
+    rank_kwargs = {"gate_lora_rank": 0, "up_lora_rank": 0, "down_lora_rank": 0}
+    rank_kwargs[f"{projection}_lora_rank"] = lora_rank
+    dispatcher = Qwen3VLMoELoRADispatcher(
+        num_layers=1,
+        lora_compute_config=LoRAComputeConfig(moe_storage="cpu", moe_compute="hybrid"),
+        **rank_kwargs,
+    )
+    dispatcher.expert_cache_manager = cache_mgr
+
+    x = torch.randn(batch_size, hidden_size, dtype=dtype, device=device)
+    bins = torch.full((batch_size,), miss_adapter_id, dtype=torch.long, device=device)
+
+    # Dummy GPU work: matmul to simulate base/hot computation
+    dummy_w = torch.randn(hidden_size, hidden_size, dtype=dtype, device=device)
+    dummy_bias = torch.randn(hidden_size, dtype=dtype, device=device)
+
+    def _dummy_gpu_work():
+        """Run dummy GPU matmul to simulate concurrent base computation."""
+        out = torch.matmul(x, dummy_w) + dummy_bias
+        torch.cuda.synchronize()
+        return out
+
+    def _run_once_with_overlap():
+        # Start timing
+        torch.cuda.synchronize()
+        wall_t0 = time.perf_counter()
+
+        # Launch dummy GPU work (simulates base/hot computation)
+        import threading
+        gpu_done_event = threading.Event()
+
+        def _gpu_thread():
+            _dummy_gpu_work()
+            gpu_done_event.set()
+
+        gpu_thread = threading.Thread(target=_gpu_thread)
+        gpu_thread.start()
+
+        # Simultaneously run the cold-miss LoRA path
+        original_record = cache_mgr.record_access
+        original_schedule = cache_mgr.schedule_promotion
+        try:
+            cache_mgr.record_access = lambda keys: None
+            cache_mgr.schedule_promotion = lambda keys: None
+            lora_out = dispatcher._batch_apply_moe_lora_hybrid(
+                input_tensor=x, layer_id=layer_id, buffer_layer_id=layer_id,
+                pool=pool, bins=bins, projection=projection, expert_id=expert_id,
+            )
+        finally:
+            cache_mgr.record_access = original_record
+            cache_mgr.schedule_promotion = original_schedule
+        if lora_out.device.type == "cuda":
+            torch.cuda.synchronize()
+
+        # Wait for GPU thread to complete
+        gpu_thread.join()
+        wall_elapsed = time.perf_counter() - wall_t0
+
+        # Get isolated service time from stats
+        stats = dispatcher.pop_colora_stats()
+        if policy == "cpu_first":
+            service_s = stats.get("cpu_compute_time", 0.0) + stats.get("admit_time", 0.0)
+        else:
+            service_s = stats.get("gpu_compute_time", 0.0) + stats.get("weight_h2d_time", 0.0) + stats.get("admit_time", 0.0)
+
+        # exposed_time = wall_time - max(gpu_dummy_time, service_time)
+        # Approximation: exposed_time = wall_time - isolated_service_time
+        # (since GPU dummy work would be running anyway)
+        exposed_s = max(wall_elapsed - service_s, 0.0)
+        return exposed_s * 1e6
+
+    # Warmup
+    for _ in range(warmup_iters):
+        _run_once_with_overlap()
+
+    # Measurement
+    exposed_samples = []
+    for _ in range(measurement_iters):
+        exposed_samples.append(_run_once_with_overlap())
+
+    return statistics.median(exposed_samples) if exposed_samples else 0.0
+
+
+# ---------------------------------------------------------------------------
+# Sweep runner
+# ---------------------------------------------------------------------------
+
+def run_sweep(config: MicrobenchConfig, overlap_benchmark: bool = False) -> None:
+    """Execute the full rank x batch x policy sweep with repeats."""
+    dtype = _dtype_from_name(config.dtype)
+
+    if config.cpu_threads > 0:
+        torch.set_num_threads(config.cpu_threads)
+
+    output_dir = Path(config.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    recovery_rows: List[Dict[str, Any]] = []
+    payload_rows: List[Dict[str, Any]] = []
+
+    policies = ["cpu_first", "load_then_run"]
+
+    for policy in policies:
+        for lora_rank in config.ranks:
+            for batch_size in config.batch_sizes:
+                print(f"policy={policy} rank={lora_rank} batch={batch_size} ...", end=" ", flush=True)
+
+                # Compute payload sizes (deterministic, same for all repeats)
+                element_bytes = torch.tensor([], dtype=dtype).element_size()
+                full_weight_bytes = 2.0 * lora_rank * config.hidden_size * element_bytes
+                activation_bytes = float(batch_size) * config.hidden_size * element_bytes
+                residual_bytes = activation_bytes
+                payload_ratio = full_weight_bytes / max(activation_bytes + residual_bytes, 1.0)
+
+                payload_rows.append({
+                    "policy": policy,
+                    "lora_rank": lora_rank,
+                    "batch_size": batch_size,
+                    "promotion_weight_bytes": full_weight_bytes,
+                    "execution_activation_bytes": activation_bytes,
+                    "execution_residual_bytes": residual_bytes,
+                    "payload_ratio": round(payload_ratio, 4),
+                })
+
+                for repeat_idx in range(1, config.repeats + 1):
+                    result = _run_cold_miss_single(
+                        policy=policy,
+                        lora_rank=lora_rank,
+                        batch_size=batch_size,
+                        hidden_size=config.hidden_size,
+                        num_experts=config.num_experts,
+                        topk=config.topk,
+                        projection=config.projection,
+                        dtype=dtype,
+                        cache_budget_mb=config.cache_budget_mb,
+                        warmup_iters=config.warmup_iters,
+                        measurement_iters=config.measurement_iters,
+                        promote_min_hits=config.promote_min_hits,
+                        promote_window=config.promote_window,
+                        max_promote_per_step=config.max_promote_per_step,
+                        decay=config.decay,
+                    )
+
+                    component_rows = _extract_component_timings(
+                        result["per_iter_stats"], policy
+                    )
+
+                    # Aggregate across iterations: median
+                    def _median_field(field: str) -> float:
+                        vals = [r[field] for r in component_rows if r[field] > 0]
+                        return statistics.median(vals) if vals else 0.0
+
+                    service_time_us = _median_field("service_time_us")
+                    component_sum_us = _median_field("component_sum_us")
+                    residual_us = abs(service_time_us - component_sum_us)
+
+                    row = {
+                        "policy": policy,
+                        "lora_rank": lora_rank,
+                        "batch_size": batch_size,
+                        "repeat_idx": repeat_idx,
+                        "service_time_us": round(service_time_us, 3),
+                        "component_sum_us": round(component_sum_us, 3),
+                        "residual_us": round(residual_us, 3),
+                        "exposed_time_us": 0.0,  # filled by overlap benchmark if enabled
+                    }
+                    for comp in ALL_COMPONENTS:
+                        row[comp] = round(_median_field(comp), 3)
+
+                    recovery_rows.append(row)
+
+                print("done")
+
+    # Optional: overlap benchmark for exposed time
+    if overlap_benchmark:
+        print("\n--- Overlap benchmark (exposed time) ---")
+        for policy in policies:
+            for lora_rank in config.ranks:
+                for batch_size in config.batch_sizes:
+                    print(f"  overlap: policy={policy} rank={lora_rank} batch={batch_size} ...", end=" ", flush=True)
+                    exposed_us = _run_overlap_benchmark(
+                        policy=policy,
+                        lora_rank=lora_rank,
+                        batch_size=batch_size,
+                        hidden_size=config.hidden_size,
+                        num_experts=config.num_experts,
+                        topk=config.topk,
+                        projection=config.projection,
+                        dtype=dtype,
+                        cache_budget_mb=config.cache_budget_mb,
+                        warmup_iters=config.warmup_iters,
+                        measurement_iters=config.measurement_iters,
+                        promote_min_hits=config.promote_min_hits,
+                        promote_window=config.promote_window,
+                        max_promote_per_step=config.max_promote_per_step,
+                        decay=config.decay,
+                    )
+                    # Write exposed time to matching recovery rows
+                    for row in recovery_rows:
+                        if (row["policy"] == policy and row["lora_rank"] == lora_rank
+                                and row["batch_size"] == batch_size):
+                            row["exposed_time_us"] = round(exposed_us, 3)
+                    print(f"exposed={exposed_us:.1f}us")
+
+    # Write CSVs
+    _write_recovery_csv(output_dir / "microbench_cold_recovery.csv", recovery_rows)
+    _write_payload_csv(output_dir / "microbench_payload_size.csv", payload_rows)
+
+    # Also write aggregated (mean across repeats)
+    agg_rows = _aggregate_repeats(recovery_rows)
+    _write_aggregated_csv(output_dir / "microbench_cold_recovery_aggregated.csv", agg_rows)
+
+    print(f"\nResults written to {output_dir}/")
+    print(f"  microbench_cold_recovery.csv       ({len(recovery_rows)} rows)")
+    print(f"  microbench_cold_recovery_aggregated.csv ({len(agg_rows)} rows)")
+    print(f"  microbench_payload_size.csv         ({len(payload_rows)} rows)")
+
+
+def _aggregate_repeats(rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Aggregate per-repeat rows into median + MAD per (policy, rank, batch).
+
+    Uses median instead of mean for robustness against warmup artifacts and outliers.
+    Median absolute deviation (MAD) is reported as the dispersion metric.
+    """
+    from collections import defaultdict
+    groups: Dict[tuple, List[Dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        key = (row["policy"], row["lora_rank"], row["batch_size"])
+        groups[key].append(row)
+
+    numeric_fields = [
+        "service_time_us", "component_sum_us", "residual_us", "exposed_time_us",
+    ] + ALL_COMPONENTS
+
+    agg_rows: List[Dict[str, Any]] = []
+    for key, group in sorted(groups.items()):
+        policy, lora_rank, batch_size = key
+        agg: Dict[str, Any] = {
+            "policy": policy,
+            "lora_rank": lora_rank,
+            "batch_size": batch_size,
+            "n_repeats": len(group),
+        }
+        for f in numeric_fields:
+            vals = [r[f] for r in group]
+            # Median for robustness against warmup artifacts and outliers
+            agg[f"{f}_median"] = round(statistics.median(vals), 3) if vals else 0.0
+            # Median absolute deviation (MAD) as robust dispersion metric
+            if vals and len(vals) > 1:
+                med = statistics.median(vals)
+                mad = statistics.median([abs(v - med) for v in vals])
+                agg[f"{f}_mad"] = round(mad, 3)
+            else:
+                agg[f"{f}_mad"] = 0.0
+        agg_rows.append(agg)
+    return agg_rows
+
+
+# ---------------------------------------------------------------------------
+# CSV writers
+# ---------------------------------------------------------------------------
+
+RECOVERY_FIELDS = [
+    "policy", "lora_rank", "batch_size", "repeat_idx",
+    "service_time_us", "component_sum_us", "residual_us",
+] + ALL_COMPONENTS + [
+    "exposed_time_us",
+]
+
+PAYLOAD_FIELDS = [
+    "policy", "lora_rank", "batch_size",
+    "promotion_weight_bytes", "execution_activation_bytes",
+    "execution_residual_bytes", "payload_ratio",
+]
+
+AGG_IDENTITY_FIELDS = ["policy", "lora_rank", "batch_size", "n_repeats"]
+AGG_NUMERIC_FIELDS = [
+    "service_time_us", "component_sum_us", "residual_us", "exposed_time_us",
+] + ALL_COMPONENTS
+AGG_FIELDS = AGG_IDENTITY_FIELDS + [
+    f"{f}_{stat}"
+    for f in AGG_NUMERIC_FIELDS
+    for stat in ("median", "mad")  # median + MAD for robustness
+]
+
+
+def _write_aggregated_csv(path: Path, rows: List[Dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=AGG_FIELDS, extrasaction="ignore")
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+
+
+def _write_recovery_csv(path: Path, rows: List[Dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=RECOVERY_FIELDS, extrasaction="ignore")
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+
+
+def _write_payload_csv(path: Path, rows: List[Dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=PAYLOAD_FIELDS, extrasaction="ignore")
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="P2 Cold Miss Recovery Microbenchmark sweep runner"
+    )
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=Path("configs/evaluation/colora_kpi/microbench_config.yaml"),
+        help="Path to microbench_config.yaml",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=str,
+        default=None,
+        help="Override output directory from config",
+    )
+    parser.add_argument(
+        "--ranks",
+        type=str,
+        default=None,
+        help="Comma-separated rank list (overrides config), e.g. 16,64",
+    )
+    parser.add_argument(
+        "--batch-sizes",
+        type=str,
+        default=None,
+        help="Comma-separated batch list (overrides config), e.g. 1,4,8",
+    )
+    parser.add_argument(
+        "--policies",
+        type=str,
+        default=None,
+        help="Comma-separated policy list (overrides config), e.g. cpu_first,load_then_run",
+    )
+    parser.add_argument(
+        "--repeats",
+        type=int,
+        default=None,
+        help="Override number of repeats from config",
+    )
+    parser.add_argument(
+        "--overlap-benchmark",
+        action="store_true",
+        default=False,
+        help="Run optional overlap benchmark for exposed-time measurement",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    config = MicrobenchConfig.from_yaml(args.config)
+
+    if args.output_dir:
+        config.output_dir = args.output_dir
+    if args.ranks:
+        config.ranks = [int(x) for x in args.ranks.split(",")]
+    if args.batch_sizes:
+        config.batch_sizes = [int(x) for x in args.batch_sizes.split(",")]
+    if args.repeats is not None:
+        config.repeats = args.repeats
+
+    print("=" * 72)
+    print("P2 Cold Miss Recovery Microbenchmark")
+    print("=" * 72)
+    print(f"  ranks:          {config.ranks}")
+    print(f"  batch_sizes:    {config.batch_sizes}")
+    print(f"  policies:       cpu_first, load_then_run")
+    print(f"  repeats:        {config.repeats}")
+    print(f"  hidden_size:    {config.hidden_size}")
+    print(f"  dtype:          {config.dtype}")
+    print(f"  output_dir:     {config.output_dir}")
+    print("=" * 72)
+
+    run_sweep(config, overlap_benchmark=args.overlap_benchmark)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/evaluation/colora_microbench_cold_recovery.py
+++ b/tools/evaluation/colora_microbench_cold_recovery.py
@@ -778,7 +778,7 @@ def run_sweep(config: MicrobenchConfig, overlap_benchmark: bool = False) -> None
     _write_recovery_csv(output_dir / "microbench_cold_recovery.csv", recovery_rows)
     _write_payload_csv(output_dir / "microbench_payload_size.csv", payload_rows)
 
-    # Also write aggregated (mean across repeats)
+    # Also write aggregated (median + MAD across repeats)
     agg_rows = _aggregate_repeats(recovery_rows)
     _write_aggregated_csv(output_dir / "microbench_cold_recovery_aggregated.csv", agg_rows)
 

--- a/tools/evaluation/p2_verify_metric.py
+++ b/tools/evaluation/p2_verify_metric.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""P2 autoresearch verify script.
+
+Runs a reduced sweep (ranks 16-64, batch 1-8) and computes the
+geometric-mean speedup of cpu_first vs load_then_run.
+
+Usage:
+  conda run -n lightllm-with-deepep python tools/evaluation/p2_verify_metric.py
+
+Output: a single float — the geometric mean of
+  (load_then_run_service_time / cpu_first_service_time)
+across all (rank, batch) configs. Higher is better.
+  >= 1.3 → pass (cpu_first 30%+ faster)
+  >= 1.5 → strong pass
+"""
+import csv
+import math
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+# Force naive CPU kernel mode for systems without AVX-512 BF16
+os.environ["COLORA_CPU_KERNEL_MODE"] = "naive"
+
+# Patch MOE_AVX_AVAILABLE to allow naive path to work
+import lightllm.models.qwen3_vl_moe.lora_dispatch as lora_dispatch_module
+lora_dispatch_module.MOE_AVX_AVAILABLE = True
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+RESULT_DIR = ROOT / "results" / "microbench_cold_recovery"
+AGG_CSV = RESULT_DIR / "microbench_cold_recovery_aggregated.csv"
+
+
+def main() -> int:
+    # Run the benchmark sweep with reduced iters for speed
+    cmd = [
+        "conda", "run", "-n", "lightllm-with-deepep",
+        "python", str(ROOT / "tools" / "evaluation" / "colora_microbench_cold_recovery.py"),
+        "--config", str(ROOT / "configs" / "evaluation" / "colora_kpi" / "microbench_config.yaml"),
+        "--ranks", "8,16,32,64",
+        "--batch-sizes", "1,2,4,8",
+        "--repeats", "5",
+    ]
+    print("Running benchmark sweep...", file=sys.stderr)
+    proc = subprocess.run(cmd, capture_output=True, text=True, timeout=600)
+    if proc.returncode != 0:
+        print(f"Benchmark FAILED (rc={proc.returncode})", file=sys.stderr)
+        print(proc.stderr[-2000:], file=sys.stderr)
+        print("0.0")  # metric-error signal
+        return 1
+
+    # Parse aggregated CSV
+    if not AGG_CSV.exists():
+        print("Aggregated CSV not found", file=sys.stderr)
+        print("0.0")
+        return 1
+
+    speedups = []
+    with AGG_CSV.open() as f:
+        reader = csv.DictReader(f)
+        rows = {(r["policy"], int(r["lora_rank"]), int(r["batch_size"])): r for r in reader}
+
+    target_configs = [(r, b) for r in (8, 16, 32, 64) for b in (1, 2, 4, 8)]
+    for rank, batch in target_configs:
+        cpu_key = ("cpu_first", rank, batch)
+        promo_key = ("load_then_run", rank, batch)
+        if cpu_key not in rows or promo_key not in rows:
+            print(f"Missing data for rank={rank} batch={batch}", file=sys.stderr)
+            continue
+        cpu_time = float(rows[cpu_key]["service_time_us_median"])
+        promo_time = float(rows[promo_key]["service_time_us_median"])
+        if cpu_time <= 0:
+            continue
+        speedup = promo_time / cpu_time
+        speedups.append(speedup)
+        print(f"  rank={rank} batch={batch}: cpu={cpu_time:.1f}us promo={promo_time:.1f}us speedup={speedup:.3f}x", file=sys.stderr)
+
+    if not speedups:
+        print("0.0")
+        return 1
+
+    # Geometric mean of speedup
+    log_sum = sum(math.log(s) for s in speedups if s > 0)
+    geom_mean = math.exp(log_sum / len(speedups))
+    print(f"\nGeometric mean speedup: {geom_mean:.4f}x ({len(speedups)} configs)", file=sys.stderr)
+
+    # Print as the metric
+    print(f"{geom_mean:.4f}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/evaluation/plot_cold_recovery_microbench.py
+++ b/tools/evaluation/plot_cold_recovery_microbench.py
@@ -1,0 +1,534 @@
+#!/usr/bin/env python3
+"""P2 Cold Recovery Microbenchmark plotting.
+
+Reads microbench_cold_recovery.csv and microbench_payload_size.csv
+from the sweep runner and produces paper-ready figures:
+
+  - fig_cold_recovery_breakdown.pdf     (stacked component bars)
+  - fig_cold_recovery_speedup_vs_rank.pdf
+  - fig_cold_recovery_speedup_vs_batch.pdf
+  - fig_cold_payload_size.pdf
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import math
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, Dict, List, Sequence, Tuple
+
+import matplotlib
+
+if "ipykernel" not in sys.modules:
+    matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+# ---------------------------------------------------------------------------
+# Style
+# ---------------------------------------------------------------------------
+
+POLICY_LABELS = {
+    "cpu_first": "Execution-first",
+    "load_then_run": "Promotion-first",
+}
+POLICY_COLORS = {
+    "cpu_first": "#2A9D8F",
+    "load_then_run": "#E76F51",
+}
+
+# Execution-first component colors (stacked bar)
+EXEC_COMPONENT_COLORS = {
+    "Tpack_us": "#264653",
+    "TD2H_activation_us": "#2A9D8F",
+    "Tcpu_us": "#E9C46A",
+    "TH2D_residual_us": "#F4A261",
+    "Tmerge_us": "#E76F51",
+}
+EXEC_COMPONENT_LABELS = {
+    "Tpack_us": "Pack",
+    "TD2H_activation_us": "D2H (activation)",
+    "Tcpu_us": "CPU compute",
+    "TH2D_residual_us": "H2D (residual)",
+    "Tmerge_us": "Merge",
+}
+
+# Promotion-first component colors (stacked bar)
+PROM_COMPONENT_COLORS = {
+    "Tadmit_us": "#355070",
+    "TH2D_weights_us": "#E76F51",
+    "Tgpu_us": "#F4A261",
+}
+PROM_COMPONENT_LABELS = {
+    "Tadmit_us": "Admission",
+    "TH2D_weights_us": "H2D (weights)",
+    "Tgpu_us": "GPU compute",
+}
+
+FIG_DPI = 150
+FIG_WIDTH = 7.0
+FIG_HEIGHT = 3.5
+
+
+# ---------------------------------------------------------------------------
+# CSV readers
+# ---------------------------------------------------------------------------
+
+def _read_csv(path: Path) -> List[Dict[str, str]]:
+    if not path.exists():
+        raise FileNotFoundError(f"CSV not found: {path}")
+    with path.open("r", encoding="utf-8", newline="") as f:
+        reader = csv.DictReader(f)
+        return [dict(row) for row in reader]
+
+
+def _float_or(val: str, default: float = 0.0) -> float:
+    try:
+        return float(val)
+    except (ValueError, TypeError):
+        return default
+
+
+# ---------------------------------------------------------------------------
+# Figure 1: Breakdown stacked bar
+# ---------------------------------------------------------------------------
+
+def plot_breakdown(
+    agg_rows: List[Dict[str, str]],
+    output_path: Path,
+) -> None:
+    """Multi-panel stacked bar: component breakdown at three representative configs.
+
+    Shows: rank=8,batch=1 (small), rank=16,batch=8 (medium), rank=64,batch=8 (large).
+    This covers the full regime of cold miss recovery behavior.
+    """
+    # Three representative configurations covering the range
+    configs = [
+        (8, 1, "rank=8, batch=1"),
+        (16, 8, "rank=16, batch=8"),
+        (64, 8, "rank=64, batch=8"),
+    ]
+
+    exec_components = list(EXEC_COMPONENT_COLORS.keys())
+    prom_components = list(PROM_COMPONENT_COLORS.keys())
+
+    # Build row lookup
+    row_lookup = {}
+    for row in agg_rows:
+        key = (int(row.get("lora_rank", 0)), int(row.get("batch_size", 0)), row.get("policy", ""))
+        row_lookup[key] = row
+
+    fig, axes = plt.subplots(1, 3, figsize=(FIG_WIDTH * 1.6, FIG_HEIGHT), sharey=True)
+
+    legend_added = set()
+
+    for ax_idx, (target_rank, target_batch, subtitle) in enumerate(configs):
+        ax = axes[ax_idx]
+
+        cpu_row = row_lookup.get((target_rank, target_batch, "cpu_first"))
+        ltr_row = row_lookup.get((target_rank, target_batch, "load_then_run"))
+
+        if cpu_row is None or ltr_row is None:
+            ax.text(0.5, 0.5, f"No data\n{subtitle}", ha="center", va="center", transform=ax.transAxes)
+            continue
+
+        exec_values = [_float_or(cpu_row.get(f"{c}_median", "0")) for c in exec_components]
+        prom_values = [_float_or(ltr_row.get(f"{c}_median", "0")) for c in prom_components]
+
+        x = np.array([0, 1])
+        bar_width = 0.6
+
+        # Execution-first stacked bar
+        bottom = 0.0
+        for comp, val in zip(exec_components, exec_values):
+            label = EXEC_COMPONENT_LABELS[comp] if comp not in legend_added else ""
+            ax.bar(x[0], max(val, 0.0), bar_width, bottom=bottom,
+                   color=EXEC_COMPONENT_COLORS[comp],
+                   label=label,
+                   edgecolor="white", linewidth=0.5)
+            legend_added.add(comp)
+            bottom += val
+
+        # Promotion-first stacked bar
+        bottom = 0.0
+        for comp, val in zip(prom_components, prom_values):
+            label = PROM_COMPONENT_LABELS[comp] if comp not in legend_added else ""
+            ax.bar(x[1], max(val, 0.0), bar_width, bottom=bottom,
+                   color=PROM_COMPONENT_COLORS[comp],
+                   label=label,
+                   edgecolor="white", linewidth=0.5)
+            legend_added.add(comp)
+            bottom += val
+
+        ax.set_xticks(x)
+        ax.set_xticklabels([
+            POLICY_LABELS.get("cpu_first", "cpu_first"),
+            POLICY_LABELS.get("load_then_run", "load_then_run"),
+        ], fontsize=8)
+        ax.set_title(subtitle, fontsize=9)
+        ax.grid(axis="y", alpha=0.3)
+
+    # Shared labels
+    axes[0].set_ylabel("Single-miss recovery service time (μs)\n(lower is better)", fontsize=10)
+    fig.suptitle("Isolated cold expert-LoRA miss recovery breakdown", fontsize=11, y=1.02)
+
+    # Single legend outside the plots
+    handles, labels = axes[0].get_legend_handles_labels()
+    fig.legend(handles, labels, fontsize=7, loc="upper right",
+               bbox_to_anchor=(0.98, 0.85), framealpha=0.9)
+
+    plt.tight_layout()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(str(output_path), dpi=FIG_DPI, bbox_inches="tight")
+    plt.close(fig)
+    print(f"Wrote {output_path}")
+
+
+# ---------------------------------------------------------------------------
+# Figure 2: Speedup vs rank
+# ---------------------------------------------------------------------------
+
+def plot_speedup_vs_rank(
+    agg_rows: List[Dict[str, str]],
+    output_path: Path,
+    fixed_batch: int = 4,
+) -> None:
+    """Line plot: speedup (promotion-first / execution-first) vs lora_rank.
+
+    Uses median + Median Absolute Deviation (MAD) for robust error bars.
+    MAD is converted to equivalent std (~1.4826 * MAD) for visualization.
+    """
+    MAD_TO_STD = 1.4826  # conversion factor for normal distribution
+
+    by_config: Dict[Tuple[int, int], Dict[str, Dict[str, float]]] = {}
+    for row in agg_rows:
+        rank = int(row.get("lora_rank", 0))
+        batch = int(row.get("batch_size", 0))
+        policy = row.get("policy", "")
+        service_time = _float_or(row.get("service_time_us_median", "0"))
+        service_mad = _float_or(row.get("service_time_us_mad", "0"))
+        key = (rank, batch)
+        if key not in by_config:
+            by_config[key] = {}
+        by_config[key][policy] = {"median": service_time, "mad": service_mad}
+
+    ranks = sorted(set(k[0] for k in by_config if k[1] == fixed_batch and k in by_config))
+    if not ranks:
+        print(f"WARNING: no data for fixed_batch={fixed_batch}, skipping speedup-vs-rank")
+        return
+
+    speedups = []
+    speedup_errors = []
+    valid_ranks = []
+
+    for rank in ranks:
+        key = (rank, fixed_batch)
+        times = by_config.get(key, {})
+        ltr_data = times.get("load_then_run", {"median": 0.0, "mad": 0.0})
+        cpu_data = times.get("cpu_first", {"median": 0.0, "mad": 0.0})
+        ltr = ltr_data["median"]
+        cpu = cpu_data["median"]
+
+        if ltr > 0 and cpu > 0:
+            speedup = ltr / cpu
+            # Error propagation for ratio: err/speedup ≈ sqrt((err_ltr/ltr)^2 + (err_cpu/cpu)^2)
+            ltr_err = ltr_data["mad"] * MAD_TO_STD
+            cpu_err = cpu_data["mad"] * MAD_TO_STD
+            rel_err = math.sqrt((ltr_err / ltr) ** 2 + (cpu_err / cpu) ** 2) if ltr > 0 and cpu > 0 else 0.0
+
+            speedups.append(speedup)
+            speedup_errors.append(speedup * rel_err)
+            valid_ranks.append(rank)
+
+    if not valid_ranks or not speedups or all(s <= 0 or math.isnan(s) for s in speedups):
+        print(f"WARNING: no valid speedup values for batch={fixed_batch}, skipping speedup-vs-rank")
+        return
+
+    fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
+    ax.errorbar(valid_ranks, speedups, yerr=speedup_errors, fmt="o-",
+                color="#2A9D8F", linewidth=2, markersize=6, capsize=3)
+    ax.axhline(y=1.0, color="gray", linestyle="--", linewidth=0.8, alpha=0.7)
+    ax.set_xlabel("LoRA rank", fontsize=10)
+    ax.set_ylabel("Speedup (promotion-first / execution-first)\n(higher is better)", fontsize=10)
+    ax.set_title(f"Cold recovery speedup vs rank (batch={fixed_batch}, median ± MAD)", fontsize=11)
+    ax.grid(alpha=0.3)
+    ax.set_xscale("log", base=2)
+    ax.set_xticks(valid_ranks)
+    ax.set_xticklabels([str(r) for r in valid_ranks])
+
+    plt.tight_layout()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(str(output_path), dpi=FIG_DPI, bbox_inches="tight")
+    plt.close(fig)
+    print(f"Wrote {output_path}")
+
+
+# ---------------------------------------------------------------------------
+# Figure 3: Speedup vs batch
+# ---------------------------------------------------------------------------
+
+def plot_speedup_vs_batch(
+    agg_rows: List[Dict[str, str]],
+    output_path: Path,
+    fixed_rank: int = 16,
+) -> None:
+    """Line plot: speedup vs cold batch size with MAD error bars."""
+    MAD_TO_STD = 1.4826
+
+    by_config: Dict[Tuple[int, int], Dict[str, Dict[str, float]]] = {}
+    for row in agg_rows:
+        rank = int(row.get("lora_rank", 0))
+        batch = int(row.get("batch_size", 0))
+        policy = row.get("policy", "")
+        service_time = _float_or(row.get("service_time_us_median", "0"))
+        service_mad = _float_or(row.get("service_time_us_mad", "0"))
+        key = (rank, batch)
+        if key not in by_config:
+            by_config[key] = {}
+        by_config[key][policy] = {"median": service_time, "mad": service_mad}
+
+    batches = sorted(set(k[1] for k in by_config if k[0] == fixed_rank and k in by_config))
+    if not batches:
+        print(f"WARNING: no data for fixed_rank={fixed_rank}, skipping speedup-vs-batch")
+        return
+
+    speedups = []
+    speedup_errors = []
+    valid_batches = []
+
+    for batch in batches:
+        key = (fixed_rank, batch)
+        times = by_config.get(key, {})
+        ltr_data = times.get("load_then_run", {"median": 0.0, "mad": 0.0})
+        cpu_data = times.get("cpu_first", {"median": 0.0, "mad": 0.0})
+        ltr = ltr_data["median"]
+        cpu = cpu_data["median"]
+
+        if ltr > 0 and cpu > 0:
+            speedup = ltr / cpu
+            ltr_err = ltr_data["mad"] * MAD_TO_STD
+            cpu_err = cpu_data["mad"] * MAD_TO_STD
+            rel_err = math.sqrt((ltr_err / ltr) ** 2 + (cpu_err / cpu) ** 2) if ltr > 0 and cpu > 0 else 0.0
+
+            speedups.append(speedup)
+            speedup_errors.append(speedup * rel_err)
+            valid_batches.append(batch)
+
+    if not valid_batches or not speedups or all(s <= 0 or math.isnan(s) for s in speedups):
+        print(f"WARNING: no valid speedup values for rank={fixed_rank}, skipping speedup-vs-batch")
+        return
+
+    fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
+    ax.errorbar(valid_batches, speedups, yerr=speedup_errors, fmt="o-",
+                color="#E76F51", linewidth=2, markersize=6, capsize=3)
+    ax.axhline(y=1.0, color="gray", linestyle="--", linewidth=0.8, alpha=0.7)
+    ax.set_xlabel("Cold batch size", fontsize=10)
+    ax.set_ylabel("Speedup (promotion-first / execution-first)\n(higher is better)", fontsize=10)
+    ax.set_title(f"Cold recovery speedup vs batch (rank={fixed_rank}, median ± MAD)", fontsize=11)
+    ax.grid(alpha=0.3)
+    ax.set_xscale("log", base=2)
+    ax.set_xticks(valid_batches)
+    ax.set_xticklabels([str(b) for b in valid_batches])
+
+    plt.tight_layout()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(str(output_path), dpi=FIG_DPI, bbox_inches="tight")
+    plt.close(fig)
+    print(f"Wrote {output_path}")
+
+
+# ---------------------------------------------------------------------------
+# Figure 4: Payload size comparison
+# ---------------------------------------------------------------------------
+
+def plot_payload_size(
+    payload_rows: List[Dict[str, str]],
+    output_path: Path,
+) -> None:
+    """Grouped bar: promotion weight bytes vs execution activation+residual bytes."""
+    # Group by rank
+    by_rank: Dict[int, Dict[str, float]] = {}
+    for row in payload_rows:
+        rank = int(row.get("lora_rank", 0))
+        policy = row.get("policy", "")
+        if rank not in by_rank:
+            by_rank[rank] = {}
+        if policy == "load_then_run":
+            by_rank[rank]["weight_bytes"] = _float_or(row.get("promotion_weight_bytes", "0"))
+        elif policy == "cpu_first":
+            by_rank[rank]["act_bytes"] = _float_or(row.get("execution_activation_bytes", "0"))
+            by_rank[rank]["res_bytes"] = _float_or(row.get("execution_residual_bytes", "0"))
+
+    # Use first batch size for each rank (all batch sizes are present; pick batch=4)
+    # Actually, payload_rows have entries per (policy, rank, batch). Filter to batch=4.
+    by_rank_fixed: Dict[int, Dict[str, float]] = {}
+    for row in payload_rows:
+        batch = int(row.get("batch_size", 0))
+        if batch != 4:
+            continue
+        rank = int(row.get("lora_rank", 0))
+        policy = row.get("policy", "")
+        if rank not in by_rank_fixed:
+            by_rank_fixed[rank] = {}
+        if policy == "load_then_run":
+            by_rank_fixed[rank]["weight_bytes"] = _float_or(row.get("promotion_weight_bytes", "0"))
+        elif policy == "cpu_first":
+            by_rank_fixed[rank]["act_bytes"] = _float_or(row.get("execution_activation_bytes", "0"))
+            by_rank_fixed[rank]["res_bytes"] = _float_or(row.get("execution_residual_bytes", "0"))
+
+    ranks = sorted(by_rank_fixed.keys())
+    if not ranks:
+        # Fallback: use any batch
+        ranks = sorted(by_rank.keys())
+        data = by_rank
+    else:
+        data = by_rank_fixed
+
+    weight_kb = [data[r].get("weight_bytes", 0) / 1024 for r in ranks]
+    exec_kb = [(data[r].get("act_bytes", 0) + data[r].get("res_bytes", 0)) / 1024 for r in ranks]
+
+    x = np.arange(len(ranks))
+    width = 0.35
+
+    fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
+    ax.bar(x - width / 2, weight_kb, width, label="Promotion: full weights", color="#E76F51", edgecolor="white")
+    ax.bar(x + width / 2, exec_kb, width, label="Execution: act. + residual", color="#2A9D8F", edgecolor="white")
+
+    ax.set_xlabel("LoRA rank", fontsize=10)
+    ax.set_ylabel("Payload size (KB)", fontsize=10)
+    ax.set_title("Synchronous payload size comparison (batch=4)", fontsize=11)
+    ax.set_xticks(x)
+    ax.set_xticklabels([str(r) for r in ranks])
+    ax.legend(fontsize=8)
+    ax.grid(axis="y", alpha=0.3)
+
+    plt.tight_layout()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(str(output_path), dpi=FIG_DPI, bbox_inches="tight")
+    plt.close(fig)
+    print(f"Wrote {output_path}")
+
+
+# ---------------------------------------------------------------------------
+# Figure 5 (optional): Exposed time
+# ---------------------------------------------------------------------------
+
+def plot_exposed_time(
+    agg_rows: List[Dict[str, str]],
+    output_path: Path,
+    fixed_rank: int = 16,
+) -> None:
+    """Grouped bar: isolated service time vs exposed time, by batch size."""
+    by_config: Dict[Tuple[str, int, int], float] = {}
+    for row in agg_rows:
+        policy = row.get("policy", "")
+        rank = int(row.get("lora_rank", 0))
+        batch = int(row.get("batch_size", 0))
+        exposed = _float_or(row.get("exposed_time_us_median", "0"))
+        service = _float_or(row.get("service_time_us_median", "0"))
+        key = (policy, rank, batch)
+        by_config[key] = {"exposed": exposed, "service": service}
+
+    batches = sorted(set(
+        k[2] for k in by_config
+        if k[1] == fixed_rank and k[0] == "cpu_first"
+    ))
+    if not batches:
+        print("WARNING: no exposed time data, skipping exposed-time figure")
+        return
+
+    # Check if any exposed_time > 0 (if overlap benchmark wasn't run, skip)
+    has_exposed = any(
+        by_config.get(("cpu_first", fixed_rank, b), {}).get("exposed", 0) > 0
+        for b in batches
+    )
+    if not has_exposed:
+        print("WARNING: all exposed_time=0 (overlap benchmark not run), skipping figure")
+        return
+
+    service_values = [
+        by_config.get(("cpu_first", fixed_rank, b), {}).get("service", 0)
+        for b in batches
+    ]
+    exposed_values = [
+        by_config.get(("cpu_first", fixed_rank, b), {}).get("exposed", 0)
+        for b in batches
+    ]
+
+    x = np.arange(len(batches))
+    width = 0.35
+
+    fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))
+    ax.bar(x - width / 2, service_values, width,
+           label="Isolated service time", color="#2A9D8F", edgecolor="white")
+    ax.bar(x + width / 2, exposed_values, width,
+           label="Exposed stall time (with overlap)", color="#E9C46A", edgecolor="white")
+
+    ax.set_xlabel("Cold batch size", fontsize=10)
+    ax.set_ylabel("Time (us)", fontsize=10)
+    ax.set_title(f"Exposed stall vs isolated service time (rank={fixed_rank}, execution-first)", fontsize=10)
+    ax.set_xticks(x)
+    ax.set_xticklabels([str(b) for b in batches])
+    ax.legend(fontsize=8)
+    ax.grid(axis="y", alpha=0.3)
+
+    plt.tight_layout()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(str(output_path), dpi=FIG_DPI, bbox_inches="tight")
+    plt.close(fig)
+    print(f"Wrote {output_path}")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Plot P2 cold recovery microbenchmark figures"
+    )
+    parser.add_argument(
+        "--input-dir",
+        type=Path,
+        default=Path("results/microbench_cold_recovery"),
+        help="Directory containing microbench CSV files",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=None,
+        help="Output directory for figures (default: same as input-dir)",
+    )
+    parser.add_argument("--fixed-batch", type=int, default=1)
+    parser.add_argument("--fixed-rank", type=int, default=16)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    input_dir = args.input_dir
+    output_dir = args.output_dir or input_dir
+
+    agg_csv = input_dir / "microbench_cold_recovery_aggregated.csv"
+    payload_csv = input_dir / "microbench_payload_size.csv"
+
+    agg_rows = _read_csv(agg_csv)
+    payload_rows = _read_csv(payload_csv)
+
+    plot_breakdown(agg_rows, output_dir / "fig_cold_recovery_breakdown.pdf")
+    plot_speedup_vs_rank(agg_rows, output_dir / "fig_cold_recovery_speedup_vs_rank.pdf", fixed_batch=args.fixed_batch)
+    plot_speedup_vs_batch(agg_rows, output_dir / "fig_cold_recovery_speedup_vs_batch.pdf", fixed_rank=args.fixed_rank)
+    plot_payload_size(payload_rows, output_dir / "fig_cold_payload_size.pdf")
+    plot_exposed_time(agg_rows, output_dir / "fig_cold_recovery_exposed_time.pdf", fixed_rank=args.fixed_rank)
+
+    print(f"\nAll figures written to {output_dir}/")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/evaluation/plot_cold_recovery_singlecol.py
+++ b/tools/evaluation/plot_cold_recovery_singlecol.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python3
+"""P2 Cold Recovery Microbenchmark plotting - single column layout.
+
+Produces a two-panel one-column figure:
+  - (a) Stacked component breakdown for one representative config
+  - (b) Compact speedup heatmap across all (rank x batch) configs
+
+Final computed data is embedded directly - no intermediate CSV processing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import matplotlib
+
+if "ipykernel" not in sys.modules:
+    matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+# ---------------------------------------------------------------------------
+# Final computed data (pre-computed from benchmark results)
+# ---------------------------------------------------------------------------
+
+# Speedup ratios = promotion-first / execution-first
+# Rows: batch = [1, 2, 4, 8] (index 0 = batch=1, index 3 = batch=8)
+# Columns: rank = [8, 16, 32, 64] (index 0 = rank=8, index 3 = rank=64)
+SPEEDUP_MATRIX = np.array([
+    [1.222, 2.122, 2.669, 5.240],   # batch=1
+    [1.738, 2.622, 2.838, 4.620],   # batch=2
+    [2.004, 2.175, 3.174, 2.196],   # batch=4
+    [2.604, 2.388, 3.714, 1.325],   # batch=8
+])
+
+# Axes labels for heatmap
+RANKS = [8, 16, 32, 64]
+BATCHES = [1, 2, 4, 8]
+
+# Stacked breakdown latencies (μs) for rank=16, batch=8 (representative config)
+BREAKDOWN_DATA = {
+    "execution_first": {
+        "cpu_compute": 75.978,
+        "data_transfer": 64.889,  # TD2H_activation + TH2D_residual
+        "other": 20.538,          # Tpack + Tmerge
+    },
+    "promotion_first": {
+        "h2d_weights": 75.04,
+        "gpu_compute": 235.675,
+        "other": 10.0,             # Tadmit
+    },
+}
+
+# Alternative: stress case (rank=64, batch=8)
+BREAKDOWN_STRESS = {
+    "execution_first": {
+        "cpu_compute": 2375.479,
+        "data_transfer": 131.210,
+        "other": 41.424,
+    },
+    "promotion_first": {
+        "h2d_weights": 6009.921,
+        "gpu_compute": 2862.005,
+        "other": 0.0,
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Style
+# ---------------------------------------------------------------------------
+
+POLICY_LABELS = {
+    "cpu_first": "Execution-first",
+    "load_then_run": "Promotion-first",
+}
+
+# Grouped component colors for simplified legend
+# Execution-first (CPU path): blue/green family
+EXEC_GROUP_COLORS = {
+    "cpu_compute": "#2A9D8F",      # Teal/green for compute
+    "data_transfer": "#219EBC",    # Blue for transfer
+    "other": "#023047",            # Dark blue for overhead
+}
+EXEC_GROUP_LABELS = {
+    "cpu_compute": "CPU LoRA compute",
+    "data_transfer": "Activation/Residual transfer",
+    "other": "Pack/Merge",
+}
+
+# Promotion-first (GPU path): orange/red family
+PROM_GROUP_COLORS = {
+    "h2d_weights": "#E76F51",      # Red for transfer
+    "gpu_compute": "#F4A261",      # Orange for compute
+    "other": "#6D6875",            # Gray for overhead
+}
+PROM_GROUP_LABELS = {
+    "h2d_weights": "H2D weights",
+    "gpu_compute": "GPU LoRA compute",
+    "other": "Admission",
+}
+
+FIG_DPI = 150
+FIG_WIDTH = 3.5   # Single column width
+FIG_HEIGHT = 5.0  # Two panels stacked vertically
+
+
+# ---------------------------------------------------------------------------
+# Panel (a): Single stacked breakdown
+# ---------------------------------------------------------------------------
+
+def plot_single_breakdown(
+    breakdown_data: dict,
+    ax: plt.Axes,
+    target_rank: int = 16,
+    target_batch: int = 8,
+) -> None:
+    """Panel (a): Stacked component breakdown for one representative config."""
+    exec_data = breakdown_data["execution_first"]
+    prom_data = breakdown_data["promotion_first"]
+
+    exec_groups = [
+        ("cpu_compute", exec_data["cpu_compute"]),
+        ("data_transfer", exec_data["data_transfer"]),
+        ("other", exec_data["other"]),
+    ]
+    prom_groups = [
+        ("h2d_weights", prom_data["h2d_weights"]),
+        ("gpu_compute", prom_data["gpu_compute"]),
+        ("other", prom_data["other"]),
+    ]
+
+    x = np.array([0, 1])
+    bar_width = 0.6
+
+    # Execution-first stacked bar
+    legend_added = set()
+    bottom = 0.0
+    for key, val in exec_groups:
+        label = EXEC_GROUP_LABELS[key] if key not in legend_added else ""
+        ax.bar(x[0], max(val, 0.0), bar_width, bottom=bottom,
+               color=EXEC_GROUP_COLORS[key],
+               label=label,
+               edgecolor="white", linewidth=0.5)
+        legend_added.add(key)
+        bottom += val
+
+    # Promotion-first stacked bar
+    bottom = 0.0
+    for key, val in prom_groups:
+        label = PROM_GROUP_LABELS[key] if key not in legend_added else ""
+        ax.bar(x[1], max(val, 0.0), bar_width, bottom=bottom,
+               color=PROM_GROUP_COLORS[key],
+               label=label,
+               edgecolor="white", linewidth=0.5)
+        legend_added.add(key)
+        bottom += val
+
+    # Total time annotations on top of each bar
+    exec_total = sum(exec_data.values())
+    prom_total = sum(prom_data.values())
+    speedup = prom_total / exec_total
+
+    # Dynamic ylim - leave 25% extra space for annotations
+    y_max = max(exec_total, prom_total) * 1.25
+
+    ax.set_xticks(x)
+    ax.set_xticklabels([
+        POLICY_LABELS["cpu_first"],
+        POLICY_LABELS["load_then_run"],
+    ], fontsize=9)
+    ax.set_ylabel("Recovery service time (μs)", fontsize=9)
+    ax.set_ylim(0, y_max)
+    ax.set_title(f"(a) breakdown (rank={target_rank}, batch={target_batch})",
+                 fontsize=10, loc="left")
+    ax.grid(axis="y", alpha=0.3)
+
+    # Bar height annotation offset
+    offset = y_max * 0.02
+
+    ax.text(x[0], exec_total + offset, f"{exec_total:.0f}",
+            ha="center", va="bottom", fontsize=8, fontweight="bold")
+    ax.text(x[1], prom_total + offset, f"{prom_total:.0f}",
+            ha="center", va="bottom", fontsize=8, fontweight="bold")
+
+    # Speedup annotation with arrow
+    anno_y = max(exec_total, prom_total) + y_max * 0.08
+    ax.annotate(f"{speedup:.1f}×",
+                xy=(x[1], anno_y),
+                xytext=(x[0], anno_y),
+                ha="center", va="center", fontsize=9, fontweight="bold",
+                arrowprops=dict(arrowstyle="<->", color="#555", lw=1.5),
+                bbox=dict(boxstyle="round,pad=0.2", facecolor="white",
+                          edgecolor="#ccc", alpha=0.9))
+
+    # Legend - compact layout
+    handles, labels = ax.get_legend_handles_labels()
+    ax.legend(handles, labels, fontsize=7, loc="upper left", framealpha=0.9)
+
+
+# ---------------------------------------------------------------------------
+# Panel (b): Speedup heatmap
+# ---------------------------------------------------------------------------
+
+def plot_speedup_heatmap(
+    speedup_matrix: np.ndarray,
+    ax: plt.Axes,
+) -> None:
+    """Panel (b): Compact heatmap of speedup = promotion-first / execution-first."""
+    # Compute geometric mean
+    geomean = np.exp(np.mean(np.log(speedup_matrix.flatten())))
+
+    # Plot heatmap - sequential colormap (darker = better speedup)
+    im = ax.imshow(speedup_matrix, cmap="YlGn", vmin=1.0, vmax=5.5,
+                   aspect="auto", origin="upper")  # origin=upper: batch=1 at top
+
+    # Set ticks and labels
+    ax.set_xticks(np.arange(len(RANKS)))
+    ax.set_xticklabels([str(r) for r in RANKS], fontsize=8)
+    ax.set_yticks(np.arange(len(BATCHES)))
+    ax.set_yticklabels([str(b) for b in BATCHES], fontsize=8)
+    ax.set_xlabel("LoRA rank", fontsize=9)
+    ax.set_ylabel("Batch size", fontsize=9)
+    ax.set_title(f"(b) Full sweep speedup (geomean {geomean:.2f}×)",
+                 fontsize=10, loc="left")
+
+    # Annotate cells - always black text for readability in print
+    for i in range(len(BATCHES)):
+        for j in range(len(RANKS)):
+            val = speedup_matrix[i, j]
+            if val > 0:
+                ax.text(j, i, f"{val:.1f}×", ha="center", va="center",
+                        fontsize=7, color="black")
+
+    # Colorbar - simplified label
+    cbar = ax.figure.colorbar(im, ax=ax, shrink=0.8)
+    cbar.set_label("Speedup (×)", fontsize=7)
+    cbar.ax.tick_params(labelsize=6)
+
+
+# ---------------------------------------------------------------------------
+# Main figure builder
+# ---------------------------------------------------------------------------
+
+def plot_singlecol_figure(
+    output_path: Path,
+    use_stress: bool = False,
+) -> None:
+    """Build the full two-panel one-column figure."""
+    fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(FIG_WIDTH, FIG_HEIGHT))
+
+    # Select breakdown config
+    if use_stress:
+        breakdown_data = BREAKDOWN_STRESS
+        target_rank = 64
+        target_batch = 8
+    else:
+        breakdown_data = BREAKDOWN_DATA
+        target_rank = 16
+        target_batch = 8
+
+    # Panel (a): stacked breakdown
+    plot_single_breakdown(breakdown_data, ax1, target_rank, target_batch)
+
+    # Panel (b): speedup heatmap
+    plot_speedup_heatmap(SPEEDUP_MATRIX, ax2)
+
+    # Overall figure title
+    # fig.suptitle("Single-miss recovery service time", fontsize=11, y=0.99)
+
+    plt.tight_layout()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(str(output_path), dpi=FIG_DPI, bbox_inches="tight")
+    plt.close(fig)
+    print(f"Wrote {output_path}")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Plot single-column cold recovery figure"
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("results/microbench_cold_recovery"),
+        help="Output directory for figures",
+    )
+    parser.add_argument(
+        "--stress",
+        action="store_true",
+        help="Use stress case (rank=64, batch=8) instead of representative",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    output_dir = args.output_dir
+
+    plot_singlecol_figure(
+        output_dir / "fig_cold_recovery_singlecol.pdf",
+        use_stress=args.stress,
+    )
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
- Implement fused naive kernel for MoE LoRA
- Optimize CPU cold path: direct float32 conversion, remove redundant checks
- Switch aggregation to median+MAD for robust benchmarking
- Update plots with paper-ready figures and labeling

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes performance-critical MoE LoRA CPU/GPU miss-path behavior and adds new AVX-512 C++ kernels; mistakes could skew benchmarking results or regress fallback latency/ correctness under cold-miss scenarios.
> 
> **Overview**
> Adds a full **P2 cold expert–LoRA miss recovery microbenchmark** that sweeps rank/batch across `cpu_first` (execution-first) vs `load_then_run` (promotion-first), writes CSVs (including median+MAD aggregation), and ships plotting scripts to generate paper figures.
> 
> Extends the MoE LoRA CPU kernel and hybrid dispatcher to better support/measure cold-miss behavior: fixes/rewrites AVX-512 BF16 paths, adds multi-adapter (per-token adapter id) CPU kernels including pool-backed variants (and an fp16-weight pool variant), introduces a fused fast path for tiny batches, and records new component timings (`pack`, `D2H activation`, `H2D residual`, `merge`, `admit`) so the microbench can produce a latency breakdown.
> 
> Also updates artifacts around the workflow (new `microbench_config.yaml`, unit tests for YAML/CSV/plot contracts, a metric verification script, `.gitignore` for outputs, and minor paper/bib citation cleanups plus a new microbenchmark section/figure placeholder in `CoLoRA.tex`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67711edfd392fad4283711ecd169da844a803420. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->